### PR TITLE
added Kruemelchen to the list of german translators

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ See [jgrpp-changelog.md](jgrpp-changelog.md) for changelog.
   * Various minor fixes, see changelog.
 
 * Translations  
-  * German (by Auge)  
+  * German (by Auge and Kruemelchen)  
   * Korean (by kiwitreekor and TELK)
 
 


### PR DESCRIPTION
I missed Kruemelchen inthe list of translators, because most of the strings was translated to german by Kruemelchen.