### PR TITLE
Fix: Fix "create group from list" command

### DIFF
--- a/src/group_cmd.cpp
+++ b/src/group_cmd.cpp
@@ -507,7 +507,7 @@ CommandCost CmdCreateGroupFromList(TileIndex tile, DoCommandFlag flags, uint32 p
 	if (!IsCompanyBuildableVehicleType(vli.vtype)) return CMD_ERROR;
 	if (!GenerateVehicleSortList(&list, vli)) return CMD_ERROR;
 
-	CommandCost ret = DoCommand(tile, vli.vtype, 0, flags, CMD_CREATE_GROUP);
+	CommandCost ret = DoCommand(tile, vli.vtype, INVALID_GROUP, flags, CMD_CREATE_GROUP);
 	if (ret.Failed()) return ret;
 
 	if (!StrEmpty(text)) {


### PR DESCRIPTION
Create group from list command does not work properly since create group command has been changed in upstream.

The involved commit is: 3a4b6b476b3de9daa0310280b3866f0eb0d805de