### PR TITLE
Improve road vehicle pathing near stops

### DIFF
--- a/src/pathfinder/yapf/yapf_road.cpp
+++ b/src/pathfinder/yapf/yapf_road.cpp
@@ -73,7 +73,7 @@ protected:
 		int cost = 0;
 
 		bool predictedOccupied = false;
-		for (int i = 0; i < MAX_TARGETS && Yapf().leaderTargets[i] != 0xFFFF; ++i) {
+		for (int i = 0; i < MAX_TARGETS && Yapf().leaderTargets[i] != INVALID_TILE; ++i) {
 			if (Yapf().leaderTargets[i] != tile) continue;
 			cost += Yapf().PfGetSettings().road_curve_penalty;
 			predictedOccupied = true;
@@ -361,7 +361,7 @@ static Vehicle * FindVehiclesOnTileProc(Vehicle *v, void *_data)
 	TileIndex ti = v->tile + TileOffsByDir(v->direction);
 
 	for (int i = 0; i < MAX_TARGETS; i++) {
-		if ((*data->targets)[i] == 0xFFFF) {
+		if ((*data->targets)[i] == INVALID_TILE) {
 			(*data->targets)[i] = ti;
 			break;
 		}
@@ -437,13 +437,12 @@ public:
 		Yapf().SetDestination(v);
 		
 		for (int i = 0; i < MAX_TARGETS; ++i) {
-			Yapf().leaderTargets[i] = 0xFFFF;
+			Yapf().leaderTargets[i] = INVALID_TILE;
 		}
 		FindVehiclesOnTileProcData data;
 		data.originVehicle = v;
 		data.targets = &Yapf().leaderTargets;
-		TileIndex ti = v->tile + TileOffsByDir(v->direction);
-		FindVehicleOnPos(ti, &data, &FindVehiclesOnTileProc);
+		FindVehicleOnPos(tile, &data, &FindVehiclesOnTileProc);
 
 		/* find the best path */
 		path_found = Yapf().FindPath(v);


### PR DESCRIPTION
This is actually a re-implementation of a small feature from an existing PR that appears to be dead at this point: https://github.com/JGRennison/OpenTTD-patches/pull/31

The improvement that caught my eye were the pathfinder changes that improved road vehicle behavior near crowded stops. The base behavior tended to result in road vehicles jamming up when turning left into stops since the leading vehicle wouldn't enter the stop quick enough for the trailing vehicle's path to be penalized for going the same way

I've taken the changes from the linked PR and cleaned them up a bit, but it's largely the same algorithm of identifying vehicles ahead of the current one and penalizing their target directions.