### PR TITLE
Fix #154: Vehicle will leave station empty if there is a per-cargo "no load" order for the just-unloaded cargo.

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1754,14 +1754,18 @@ static void LoadUnloadVehicle(Vehicle *front)
 			continue;
 		}
 
-		/* Do not pick up goods when we have no-load set or loading is stopped. */
-		if (GetLoadType(v) & OLFB_NO_LOAD || HasBit(front->vehicle_flags, VF_STOP_LOADING)) continue;
+		/* Do not pick up goods when we have no-load set or loading is stopped.
+		 * Per-cargo no-load orders can only be checked after attempting to refit. */
+		if (front->current_order.GetLoadType() & OLFB_NO_LOAD || HasBit(front->vehicle_flags, VF_STOP_LOADING)) continue;
 
 		/* This order has a refit, if this is the first vehicle part carrying cargo and the whole vehicle is empty, try refitting. */
 		if (front->current_order.IsRefit() && artic_part == 1) {
 			HandleStationRefit(v, consist_capleft, st, next_station, front->current_order.GetRefitCargo());
 			ge = &st->goods[v->cargo_type];
 		}
+
+		/* Do not pick up goods when we have no-load set. */
+		if (GetLoadType(v) & OLFB_NO_LOAD) continue;
 
 		/* As we're loading here the following link can carry the full capacity of the vehicle. */
 		v->refit_cap = v->cargo_cap;


### PR DESCRIPTION
I’m still getting the hang of git, so if there’s a better way of doing things, please let me know.

This is the patch to fix issue #154 that I opened earlier today.