### PR TITLE
Gamescript river construction

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -385,7 +385,7 @@ static const Command _command_proc_table[] = {
 	DEF_CMD(CmdMoneyCheatAdmin,                    CMD_SERVER_NS, CMDT_CHEAT                 ), // CMD_MONEY_CHEAT_ADMIN
 	DEF_CMD(CmdChangeBankBalance,                      CMD_DEITY, CMDT_MONEY_MANAGEMENT      ), // CMD_CHANGE_BANK_BALANCE
 	DEF_CMD(CmdCheatSetting,                          CMD_SERVER, CMDT_CHEAT                 ), // CMD_CHEAT_SETTING
-	DEF_CMD(CmdBuildCanal,                              CMD_AUTO, CMDT_LANDSCAPE_CONSTRUCTION), // CMD_BUILD_CANAL
+	DEF_CMD(CmdBuildCanal,                  CMD_DEITY | CMD_AUTO, CMDT_LANDSCAPE_CONSTRUCTION), // CMD_BUILD_CANAL
 	DEF_CMD(CmdCreateSubsidy,                          CMD_DEITY, CMDT_OTHER_MANAGEMENT      ), // CMD_CREATE_SUBSIDY
 	DEF_CMD(CmdCompanyCtrl, CMD_SPECTATOR | CMD_CLIENT_ID | CMD_NO_EST, CMDT_SERVER_SETTING  ), // CMD_COMPANY_CTRL
 	DEF_CMD(CmdCustomNewsItem,          CMD_STR_CTRL | CMD_DEITY, CMDT_OTHER_MANAGEMENT      ), // CMD_CUSTOM_NEWS_ITEM

--- a/src/script/api/ai/ai_marine.hpp.sq
+++ b/src/script/api/ai/ai_marine.hpp.sq
@@ -40,6 +40,7 @@ void SQAIMarine_Register(Squirrel *engine)
 	SQAIMarine.DefSQStaticMethod(engine, &ScriptMarine::BuildBuoy,              "BuildBuoy",              2, ".i");
 	SQAIMarine.DefSQStaticMethod(engine, &ScriptMarine::BuildLock,              "BuildLock",              2, ".i");
 	SQAIMarine.DefSQStaticMethod(engine, &ScriptMarine::BuildCanal,             "BuildCanal",             2, ".i");
+	SQAIMarine.DefSQStaticMethod(engine, &ScriptMarine::BuildRiver,             "BuildRiver",             2, ".i");
 	SQAIMarine.DefSQStaticMethod(engine, &ScriptMarine::RemoveWaterDepot,       "RemoveWaterDepot",       2, ".i");
 	SQAIMarine.DefSQStaticMethod(engine, &ScriptMarine::RemoveDock,             "RemoveDock",             2, ".i");
 	SQAIMarine.DefSQStaticMethod(engine, &ScriptMarine::RemoveBuoy,             "RemoveBuoy",             2, ".i");

--- a/src/script/api/game/game_marine.hpp.sq
+++ b/src/script/api/game/game_marine.hpp.sq
@@ -40,6 +40,7 @@ void SQGSMarine_Register(Squirrel *engine)
 	SQGSMarine.DefSQStaticMethod(engine, &ScriptMarine::BuildBuoy,              "BuildBuoy",              2, ".i");
 	SQGSMarine.DefSQStaticMethod(engine, &ScriptMarine::BuildLock,              "BuildLock",              2, ".i");
 	SQGSMarine.DefSQStaticMethod(engine, &ScriptMarine::BuildCanal,             "BuildCanal",             2, ".i");
+	SQGSMarine.DefSQStaticMethod(engine, &ScriptMarine::BuildRiver,             "BuildRiver",             2, ".i");
 	SQGSMarine.DefSQStaticMethod(engine, &ScriptMarine::RemoveWaterDepot,       "RemoveWaterDepot",       2, ".i");
 	SQGSMarine.DefSQStaticMethod(engine, &ScriptMarine::RemoveDock,             "RemoveDock",             2, ".i");
 	SQGSMarine.DefSQStaticMethod(engine, &ScriptMarine::RemoveBuoy,             "RemoveBuoy",             2, ".i");

--- a/src/script/api/script_marine.cpp
+++ b/src/script/api/script_marine.cpp
@@ -116,6 +116,13 @@
 	return ScriptObject::DoCommand(tile, tile, WATER_CLASS_CANAL, CMD_BUILD_CANAL);
 }
 
+/* static */ bool ScriptMarine::BuildRiver(TileIndex tile)
+{
+	EnforcePrecondition(false, ::IsValidTile(tile));
+
+	return ScriptObject::DoCommand(tile, tile, WATER_CLASS_RIVER, CMD_BUILD_CANAL);
+}
+
 /* static */ bool ScriptMarine::RemoveWaterDepot(TileIndex tile)
 {
 	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);

--- a/src/script/api/script_marine.hpp
+++ b/src/script/api/script_marine.hpp
@@ -159,6 +159,18 @@ public:
 	static bool BuildCanal(TileIndex tile);
 
 	/**
+	 * Builds a river on tile.
+	 * @param tile The tile where the canal will be build.
+	 * @pre ScriptMap::IsValidTile(tile).
+	 * @exception ScriptError::ERR_AREA_NOT_CLEAR
+	 * @exception ScriptError::ERR_LAND_SLOPED_WRONG
+	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
+	 * @exception ScriptError::ERR_ALREADY_BUILT
+	 * @return Whether the river has been/can be build or not.
+	 */
+	static bool BuildRiver(TileIndex tile);
+
+	/**
 	 * Removes a water depot.
 	 * @param tile Any tile of the water depot.
 	 * @pre ScriptMap::IsValidTile(tile).

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -455,7 +455,9 @@ CommandCost CmdBuildCanal(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32
 	if (_game_mode != GM_EDITOR) {
 		if (HasBit(p2, 2)) return CMD_ERROR;
 		if (wc == WATER_CLASS_RIVER) {
-			if (!_settings_game.construction.enable_build_river) return CMD_ERROR;
+			if (!_settings_game.construction.enable_build_river && _current_company != OWNER_DEITY) {
+				return CMD_ERROR;
+			}
 		} else if (wc != WATER_CLASS_CANAL) {
 			return CMD_ERROR;
 		}


### PR DESCRIPTION
## Summary
This feature adds a BuildRiver game script command and loosens the company restriction to allow game scripts to construct rivers as the deity company.

## Motivation
Currently the process of creating maps styled after real-world maps lacks any mechanism to supply a water map (akin to the heightmap) when creating maps. Proper support for this would be nice but involves a few rather large decisions that broadly affect either how heightmaps behave or the UI surrounding importing them. 

The current map generation process involves generating a game script to fill in water using the BuildCanal game script function as there's no BuildRiver. Likewise these canals must be built by a real company. To improve this process the BuildRiver game script command is added so actual rivers can be created (provided the game settings allow the creation of rivers).

## Possible Issues
* The build river command depends on river construction being allowed in the game settings even if the river is being created by the deity company. It may make more sense to always allow river creation if the current company is the deity company.
* Since building rivers is a special case of building canals it's possible that allowing the deity company to execute this command could have unexpected results that I'm not aware of.
