### PR TITLE
This patch allows configuring the town zone size multipliers in towns…

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1884,6 +1884,16 @@ STR_CONFIG_SETTING_ZOOM_LVL_OUT_64X                             :64x
 STR_CONFIG_SETTING_ZOOM_LVL_OUT_128X                            :128x
 STR_CONFIG_SETTING_TOWN_GROWTH                                  :Town growth speed: {STRING2}
 STR_CONFIG_SETTING_TOWN_GROWTH_HELPTEXT                         :Speed of town growth
+STR_CONFIG_SETTING_TOWN_ZONE_0_MULT                             :Multiplier to Zone 0: {STRING2}
+STR_CONFIG_SETTING_TOWN_ZONE_0_MULT_HELPTEXT                    :Multiplier to the size of Zone 0 when towns have greater than 92 houses.
+STR_CONFIG_SETTING_TOWN_ZONE_1_MULT                             :Multiplier to Zone 1: {STRING2}
+STR_CONFIG_SETTING_TOWN_ZONE_1_MULT_HELPTEXT                    :Multiplier to the size of Zone 1 when towns have greater than 92 houses.
+STR_CONFIG_SETTING_TOWN_ZONE_2_MULT                             :Multiplier to Zone 2: {STRING2}
+STR_CONFIG_SETTING_TOWN_ZONE_2_MULT_HELPTEXT                    :Multiplier to the size of Zone 2 when towns have greater than 92 houses.
+STR_CONFIG_SETTING_TOWN_ZONE_3_MULT                             :Multiplier to Zone 3: {STRING2}
+STR_CONFIG_SETTING_TOWN_ZONE_3_MULT_HELPTEXT                    :Multiplier to the size of Zone 3 when towns have greater than 92 houses.
+STR_CONFIG_SETTING_TOWN_ZONE_4_MULT                             :Multiplier to Zone 4: {STRING2}
+STR_CONFIG_SETTING_TOWN_ZONE_4_MULT_HELPTEXT                    :Multiplier to the size of Zone 4 when towns have greater than 92 houses.
 STR_CONFIG_SETTING_TOWN_GROWTH_CARGO_TRANSPORTED                :Town growth speed depends on transported cargo: {STRING2}
 STR_CONFIG_SETTING_TOWN_GROWTH_CARGO_TRANSPORTED_HELPTEXT       :Percentage of town growth speed which depends on proportion of town cargo transported in the last month
 STR_CONFIG_SETTING_TOWN_GROWTH_EXTREME_SLOW                     :Extremely slow

--- a/src/lang/english_AU.txt
+++ b/src/lang/english_AU.txt
@@ -1559,6 +1559,16 @@ STR_CONFIG_SETTING_TOWN_GROWTH_SLOW                             :Slow
 STR_CONFIG_SETTING_TOWN_GROWTH_NORMAL                           :Normal
 STR_CONFIG_SETTING_TOWN_GROWTH_FAST                             :Fast
 STR_CONFIG_SETTING_TOWN_GROWTH_VERY_FAST                        :Very fast
+STR_CONFIG_SETTING_TOWN_ZONE_0_MULT                             :Multiplier to Zone 0: {STRING2}
+STR_CONFIG_SETTING_TOWN_ZONE_0_MULT_HELPTEXT                    :Multiplier to the size of Zone 0 when towns have greater than 92 houses.
+STR_CONFIG_SETTING_TOWN_ZONE_1_MULT                             :Multiplier to Zone 1: {STRING2}
+STR_CONFIG_SETTING_TOWN_ZONE_1_MULT_HELPTEXT                    :Multiplier to the size of Zone 1 when towns have greater than 92 houses.
+STR_CONFIG_SETTING_TOWN_ZONE_2_MULT                             :Multiplier to Zone 2: {STRING2}
+STR_CONFIG_SETTING_TOWN_ZONE_2_MULT_HELPTEXT                    :Multiplier to the size of Zone 2 when towns have greater than 92 houses.
+STR_CONFIG_SETTING_TOWN_ZONE_3_MULT                             :Multiplier to Zone 3: {STRING2}
+STR_CONFIG_SETTING_TOWN_ZONE_3_MULT_HELPTEXT                    :Multiplier to the size of Zone 3 when towns have greater than 92 houses.
+STR_CONFIG_SETTING_TOWN_ZONE_4_MULT                             :Multiplier to Zone 4: {STRING2}
+STR_CONFIG_SETTING_TOWN_ZONE_4_MULT_HELPTEXT                    :Multiplier to the size of Zone 4 when towns have greater than 92 houses.
 STR_CONFIG_SETTING_LARGER_TOWNS                                 :Proportion of towns that will become cities: {STRING}
 STR_CONFIG_SETTING_LARGER_TOWNS_HELPTEXT                        :Amount of towns which will become a city, thus a town which starts out larger and grows faster
 STR_CONFIG_SETTING_LARGER_TOWNS_VALUE                           :1 in {COMMA}

--- a/src/lang/english_US.txt
+++ b/src/lang/english_US.txt
@@ -1661,6 +1661,16 @@ STR_CONFIG_SETTING_TOWN_GROWTH_SLOW                             :Slow
 STR_CONFIG_SETTING_TOWN_GROWTH_NORMAL                           :Normal
 STR_CONFIG_SETTING_TOWN_GROWTH_FAST                             :Fast
 STR_CONFIG_SETTING_TOWN_GROWTH_VERY_FAST                        :Very fast
+STR_CONFIG_SETTING_TOWN_ZONE_0_MULT                             :Multiplier to Zone 0: {STRING2}
+STR_CONFIG_SETTING_TOWN_ZONE_0_MULT_HELPTEXT                    :Multiplier to the size of Zone 0 when towns have greater than 92 houses.
+STR_CONFIG_SETTING_TOWN_ZONE_1_MULT                             :Multiplier to Zone 1: {STRING2}
+STR_CONFIG_SETTING_TOWN_ZONE_1_MULT_HELPTEXT                    :Multiplier to the size of Zone 1 when towns have greater than 92 houses.
+STR_CONFIG_SETTING_TOWN_ZONE_2_MULT                             :Multiplier to Zone 2: {STRING2}
+STR_CONFIG_SETTING_TOWN_ZONE_2_MULT_HELPTEXT                    :Multiplier to the size of Zone 2 when towns have greater than 92 houses.
+STR_CONFIG_SETTING_TOWN_ZONE_3_MULT                             :Multiplier to Zone 3: {STRING2}
+STR_CONFIG_SETTING_TOWN_ZONE_3_MULT_HELPTEXT                    :Multiplier to the size of Zone 3 when towns have greater than 92 houses.
+STR_CONFIG_SETTING_TOWN_ZONE_4_MULT                             :Multiplier to Zone 4: {STRING2}
+STR_CONFIG_SETTING_TOWN_ZONE_4_MULT_HELPTEXT                    :Multiplier to the size of Zone 4 when towns have greater than 92 houses.
 STR_CONFIG_SETTING_LARGER_TOWNS                                 :Proportion of towns that will become cities: {STRING}
 STR_CONFIG_SETTING_LARGER_TOWNS_HELPTEXT                        :Amount of towns which will become a city, thus a town which starts out larger and grows faster
 STR_CONFIG_SETTING_LARGER_TOWNS_VALUE                           :1 in {COMMA}

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1842,6 +1842,11 @@ static SettingsContainer &GetSettingsTree()
 			{
 				towns->Add(new SettingEntry("economy.town_growth_rate"));
 				towns->Add(new SettingEntry("economy.town_growth_cargo_transported"));
+				towns->Add(new SettingEntry("economy.town_zone_0_mult"));
+				towns->Add(new SettingEntry("economy.town_zone_1_mult"));
+				towns->Add(new SettingEntry("economy.town_zone_2_mult"));
+				towns->Add(new SettingEntry("economy.town_zone_3_mult"));
+				towns->Add(new SettingEntry("economy.town_zone_4_mult"));
 				towns->Add(new SettingEntry("economy.allow_town_roads"));
 				towns->Add(new SettingEntry("economy.allow_town_level_crossings"));
 				towns->Add(new SettingEntry("economy.found_town"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -600,6 +600,11 @@ struct EconomySettings {
 	bool   multiple_industry_per_town;       ///< allow many industries of the same type per town
 	int8   town_growth_rate;                 ///< town growth rate
 	uint8  town_growth_cargo_transported;    ///< percentage of town growth rate which depends on proportion of transported cargo in the last month
+	uint16  town_zone_0_mult;                 ///< multiplier for the size of zone 0 when towns are over 92houses
+	uint16  town_zone_1_mult;                 ///< multiplier for the size of zone 1 when towns are over 92houses
+	uint16  town_zone_2_mult;                 ///< multiplier for the size of zone 2 when towns are over 92houses
+	uint16  town_zone_3_mult;                 ///< multiplier for the size of zone 3 when towns are over 92houses
+	uint16  town_zone_4_mult;                 ///< multiplier for the size of zone 4 when towns are over 92houses
 	uint8  larger_towns;                     ///< the number of cities to build. These start off larger and grow twice as fast
 	uint8  initial_city_size;                ///< multiplier for the initial size of the cities compared to towns
 	TownLayout town_layout;                  ///< select town layout, @see TownLayout

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -2386,6 +2386,66 @@ orderproc = OrderTownGrowthRate
 
 [SDT_VAR]
 base     = GameSettings
+var      = economy.town_zone_0_mult
+type     = SLE_UINT16
+def      = 15
+min      = 0
+max      = 255
+interval = 1
+str      = STR_CONFIG_SETTING_TOWN_ZONE_0_MULT
+strhelp  = STR_CONFIG_SETTING_TOWN_ZONE_0_MULT_HELPTEXT
+strval   = STR_JUST_COMMA
+
+[SDT_VAR]
+base     = GameSettings
+var      = economy.town_zone_1_mult
+type     = SLE_UINT16
+def      = 9
+min      = 0
+max      = 255
+interval = 1
+str      = STR_CONFIG_SETTING_TOWN_ZONE_1_MULT
+strhelp  = STR_CONFIG_SETTING_TOWN_ZONE_1_MULT_HELPTEXT
+strval   = STR_JUST_COMMA
+
+[SDT_VAR]
+base     = GameSettings
+var      = economy.town_zone_2_mult
+type     = SLE_UINT16
+def      = 0
+min      = 0
+max      = 255
+interval = 1
+str      = STR_CONFIG_SETTING_TOWN_ZONE_2_MULT
+strhelp  = STR_CONFIG_SETTING_TOWN_ZONE_2_MULT_HELPTEXT
+strval   = STR_JUST_COMMA
+
+[SDT_VAR]
+base     = GameSettings
+var      = economy.town_zone_3_mult
+type     = SLE_UINT16
+def      = 5
+min      = 0
+max      = 255
+interval = 1
+str      = STR_CONFIG_SETTING_TOWN_ZONE_3_MULT
+strhelp  = STR_CONFIG_SETTING_TOWN_ZONE_3_MULT_HELPTEXT
+strval   = STR_JUST_COMMA
+
+[SDT_VAR]
+base     = GameSettings
+var      = economy.town_zone_4_mult
+type     = SLE_UINT16
+def      = 3
+min      = 0
+max      = 255
+interval = 1
+str      = STR_CONFIG_SETTING_TOWN_ZONE_4_MULT
+strhelp  = STR_CONFIG_SETTING_TOWN_ZONE_4_MULT_HELPTEXT
+strval   = STR_JUST_COMMA
+
+[SDT_VAR]
+base     = GameSettings
 var      = economy.town_growth_cargo_transported
 type     = SLE_UINT8
 def      = 0

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -1985,11 +1985,13 @@ void UpdateTownRadius(Town *t)
 		/* Actually we are proportional to sqrt() but that's right because we are covering an area.
 		 * The offsets are to make sure the radii do not decrease in size when going from the table
 		 * to the calculated value.*/
-		t->cache.squared_town_zone_radius[0] = mass * 15 - 40;
-		t->cache.squared_town_zone_radius[1] = mass * 9 - 15;
-		t->cache.squared_town_zone_radius[2] = 0;
-		t->cache.squared_town_zone_radius[3] = mass * 5 - 5;
-		t->cache.squared_town_zone_radius[4] = mass * 3 + 5;
+		/* Here we have added in the additional parameters that allow players to change the size
+		 * of these multipliers, the multipliers default values match the values previously found.*/
+		t->cache.squared_town_zone_radius[0] = mass * _settings_game.economy.town_zone_0_mult - 40;
+		t->cache.squared_town_zone_radius[1] = mass * _settings_game.economy.town_zone_1_mult - 15;
+		t->cache.squared_town_zone_radius[2] = mass * _settings_game.economy.town_zone_2_mult;
+		t->cache.squared_town_zone_radius[3] = mass * _settings_game.economy.town_zone_3_mult - 5;
+		t->cache.squared_town_zone_radius[4] = mass * _settings_game.economy.town_zone_4_mult + 5;
 	}
 }
 


### PR DESCRIPTION
Please be gentle, I've never written a PR before:

This patch allows configuring the Town Zone Size multipliers in town_cmd.cpp, this only affects the calculated values used after line entry 23 on the table previously, so it only affects towns 92 houses or above in size.

The default values for these are the current multipliers already specified in town_cmd.cpp, so defaults should result in totally default behavior.

So-far I've tested this in game and while the values themselves are probably going to be difficult to understand, they appear to be safe to change even on the fly in an existing game, I've set the values to allow a max of 255 but better results seem to be achieved with smaller values in-game. A particular favorite is to immediately change zone 4 to 1 instead of the default 3 and also set zone 2 to slightly higher values.