### PR TITLE
More rocks landscape options

### DIFF
--- a/src/clear_cmd.cpp
+++ b/src/clear_cmd.cpp
@@ -365,7 +365,7 @@ void GenerateClearTile()
 
 		IncreaseGeneratingWorldProgress(GWP_ROUGH_ROCKY);
 		if (IsTileType(tile, MP_CLEAR) && !IsClearGround(tile, CLEAR_DESERT)) {
-			uint j = GB(r, 16, 4) + 5;
+			uint j = GB(r, 16, 4) + _settings_game.game_creation.amount_of_rocks;
 			for (;;) {
 				TileIndex tile_new;
 

--- a/src/clear_cmd.cpp
+++ b/src/clear_cmd.cpp
@@ -365,9 +365,9 @@ void GenerateClearTile()
 
 		IncreaseGeneratingWorldProgress(GWP_ROUGH_ROCKY);
 		if (IsTileType(tile, MP_CLEAR) && !IsClearGround(tile, CLEAR_DESERT)) {
-			uint j = GB(r, 16, 4) + _settings_game.game_creation.amount_of_rocks;
+			uint j = GB(r, 16, 4) + _settings_game.game_creation.amount_of_rocks + ((int)TileHeight(tile) * _settings_game.game_creation.height_affects_rocks);
 			for (;;) {
-				TileIndex tile_new;
+				TileIndex tile_new; 
 
 				SetClearGroundDensity(tile, CLEAR_ROCKS, 3);
 				do {

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1461,6 +1461,8 @@ STR_CONFIG_SETTING_RIVER_AMOUNT                                 :River amount: {
 STR_CONFIG_SETTING_RIVER_AMOUNT_HELPTEXT                        :Choose how many rivers to generate
 STR_CONFIG_SETTING_ROCKS_AMOUNT                                 :Rocks amount: {STRING}
 STR_CONFIG_SETTING_ROCKS_AMOUNT_HELPTEXT                        :Determines the size of rocky patches. High values can cover a significant portion of the map.
+STR_CONFIG_SETTING_HEIGHT_ROCKS                                 :Rocks height modifier: {STRING}
+STR_CONFIG_SETTING_HEIGHT_ROCKS_HELPTEXT                        :Determines how much rocky patch distribution is affected by height. This is cumulative with the Rocks Amount setting and works best when the Rocks amount setting is set to lower values.
 STR_CONFIG_SETTING_TREE_PLACER                                  :Tree placer algorithm: {STRING2}
 STR_CONFIG_SETTING_TREE_PLACER_HELPTEXT                         :Choose the distribution of trees on the map: 'Original' plants trees uniformly scattered, 'Improved' plants them in groups
 STR_CONFIG_SETTING_TREE_PLACER_NONE                             :None

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4190,6 +4190,10 @@ STR_FINANCES_BORROW_BUTTON                                      :{BLACK}Borrow {
 STR_FINANCES_BORROW_TOOLTIP                                     :{BLACK}Increase size of loan. Ctrl+Click borrows as much as possible
 STR_FINANCES_REPAY_BUTTON                                       :{BLACK}Repay {CURRENCY_LONG}
 STR_FINANCES_REPAY_TOOLTIP                                      :{BLACK}Repay part of loan. Ctrl+Click repays as much loan as possible
+STR_FINANCES_BORROW_TOOLTIP_EXTRA                               :{BLACK}{STRING}. Shift+Click to enter an amount to borrow
+STR_FINANCES_REPAY_TOOLTIP_EXTRA                                :{BLACK}{STRING}. Shift+Click to enter an amount to repay
+STR_FINANCES_BORROW_QUERY_CAPT                                  :{WHITE}Enter the amount of money to borrow
+STR_FINANCES_REPAY_QUERY_CAPT                                   :{WHITE}Enter the amount of money to repay
 STR_FINANCES_INFRASTRUCTURE_BUTTON                              :{BLACK}Infrastructure
 
 # Company view

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1459,8 +1459,8 @@ STR_CONFIG_SETTING_VARIETY                                      :Variety distrib
 STR_CONFIG_SETTING_VARIETY_HELPTEXT                             :(TerraGenesis only) Control whether the map contains both mountainous and flat areas. Since this only makes the map flatter, other settings should be set to mountainous
 STR_CONFIG_SETTING_RIVER_AMOUNT                                 :River amount: {STRING2}
 STR_CONFIG_SETTING_RIVER_AMOUNT_HELPTEXT                        :Choose how many rivers to generate
-STR_CONFIG_SETTING_ROCKS_AMOUNT                                 :Rocks amount: {NUM}
-STR_CONFIG_SETTING_ROCKS_AMOUNT_HELPTEXT                        :Choose how many rocky patches to generate
+STR_CONFIG_SETTING_ROCKS_AMOUNT                                 :Rocks amount: {STRING}
+STR_CONFIG_SETTING_ROCKS_AMOUNT_HELPTEXT                        :Determines the size of rocky patches. High values can cover a significant portion of the map.
 STR_CONFIG_SETTING_TREE_PLACER                                  :Tree placer algorithm: {STRING2}
 STR_CONFIG_SETTING_TREE_PLACER_HELPTEXT                         :Choose the distribution of trees on the map: 'Original' plants trees uniformly scattered, 'Improved' plants them in groups
 STR_CONFIG_SETTING_TREE_PLACER_NONE                             :None

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1459,6 +1459,8 @@ STR_CONFIG_SETTING_VARIETY                                      :Variety distrib
 STR_CONFIG_SETTING_VARIETY_HELPTEXT                             :(TerraGenesis only) Control whether the map contains both mountainous and flat areas. Since this only makes the map flatter, other settings should be set to mountainous
 STR_CONFIG_SETTING_RIVER_AMOUNT                                 :River amount: {STRING2}
 STR_CONFIG_SETTING_RIVER_AMOUNT_HELPTEXT                        :Choose how many rivers to generate
+STR_CONFIG_SETTING_ROCKS_AMOUNT                                 :Rocks amount: {NUM}
+STR_CONFIG_SETTING_ROCKS_AMOUNT_HELPTEXT                        :Choose how many rocky patches to generate
 STR_CONFIG_SETTING_TREE_PLACER                                  :Tree placer algorithm: {STRING2}
 STR_CONFIG_SETTING_TREE_PLACER_HELPTEXT                         :Choose the distribution of trees on the map: 'Original' plants trees uniformly scattered, 'Improved' plants them in groups
 STR_CONFIG_SETTING_TREE_PLACER_NONE                             :None

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1816,6 +1816,7 @@ static SettingsContainer &GetSettingsTree()
 			genworld->Add(new SettingEntry("game_creation.snow_line_height"));
 			genworld->Add(new SettingEntry("game_creation.rainforest_line_height"));
 			genworld->Add(new SettingEntry("game_creation.amount_of_rivers"));
+			genworld->Add(new SettingEntry("game_creation.amount_of_rocks"));
 			genworld->Add(new SettingEntry("game_creation.tree_placer"));
 			genworld->Add(new SettingEntry("vehicle.road_side"));
 			genworld->Add(new SettingEntry("economy.larger_towns"));

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1817,6 +1817,7 @@ static SettingsContainer &GetSettingsTree()
 			genworld->Add(new SettingEntry("game_creation.rainforest_line_height"));
 			genworld->Add(new SettingEntry("game_creation.amount_of_rivers"));
 			genworld->Add(new SettingEntry("game_creation.amount_of_rocks"));
+			genworld->Add(new SettingEntry("game_creation.height_affects_rocks"));
 			genworld->Add(new SettingEntry("game_creation.tree_placer"));
 			genworld->Add(new SettingEntry("vehicle.road_side"));
 			genworld->Add(new SettingEntry("economy.larger_towns"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -375,7 +375,7 @@ struct GameCreationSettings {
 	byte   min_river_length;                 ///< the minimum river length
 	byte   river_route_random;               ///< the amount of randomicity for the route finding
 	byte   amount_of_rivers;                 ///< the amount of rivers
-	byte   amount_of_rocks;                  ///< the amoutn of rocks
+	uint8  amount_of_rocks;                  ///< the amoutn of rocks
 };
 
 /** Settings related to construction in-game */

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -375,6 +375,7 @@ struct GameCreationSettings {
 	byte   min_river_length;                 ///< the minimum river length
 	byte   river_route_random;               ///< the amount of randomicity for the route finding
 	byte   amount_of_rivers;                 ///< the amount of rivers
+	byte   amount_of_rocks;                  ///< the amoutn of rocks
 };
 
 /** Settings related to construction in-game */

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -376,6 +376,7 @@ struct GameCreationSettings {
 	byte   river_route_random;               ///< the amount of randomicity for the route finding
 	byte   amount_of_rivers;                 ///< the amount of rivers
 	uint8  amount_of_rocks;                  ///< the amount of rocks
+	uint8  height_affects_rocks;              ///< the affect that map height has on rocks
 };
 
 /** Settings related to construction in-game */

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -375,7 +375,7 @@ struct GameCreationSettings {
 	byte   min_river_length;                 ///< the minimum river length
 	byte   river_route_random;               ///< the amount of randomicity for the route finding
 	byte   amount_of_rivers;                 ///< the amount of rivers
-	uint8  amount_of_rocks;                  ///< the amoutn of rocks
+	uint8  amount_of_rocks;                  ///< the amount of rocks
 };
 
 /** Settings related to construction in-game */

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -3750,6 +3750,18 @@ str      = STR_CONFIG_SETTING_RIVER_AMOUNT
 strhelp  = STR_CONFIG_SETTING_RIVER_AMOUNT_HELPTEXT
 strval   = STR_RIVERS_NONE
 
+[SDT_VAR]
+base     = GameSettings
+var      = game_creation.amount_of_rocks
+type     = SLE_UINT8
+def      = 5
+min      = 1
+max      = 255
+interval = 1
+str      = STR_CONFIG_SETTING_ROCKS_AMOUNT
+strhelp  = STR_CONFIG_SETTING_ROCKS_AMOUNT_HELPTEXT
+strval   = STR_JUST_COMMA
+
 ;;game_creation.build_public_roads
 [SDT_NULL]
 length   = 1

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -3754,6 +3754,7 @@ strval   = STR_RIVERS_NONE
 base     = GameSettings
 var      = game_creation.amount_of_rocks
 type     = SLE_UINT8
+guiflags = SGF_NEWGAME_ONLY | SGF_SCENEDIT_TOO
 def      = 5
 min      = 1
 max      = 255

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -3763,6 +3763,19 @@ str      = STR_CONFIG_SETTING_ROCKS_AMOUNT
 strhelp  = STR_CONFIG_SETTING_ROCKS_AMOUNT_HELPTEXT
 strval   = STR_JUST_COMMA
 
+[SDT_VAR]
+base     = GameSettings
+var      = game_creation.height_affects_rocks
+type     = SLE_UINT8
+guiflags = SGF_NEWGAME_ONLY | SGF_SCENEDIT_TOO
+def      = 0
+min      = 0
+max      = 25
+interval = 1
+str      = STR_CONFIG_SETTING_HEIGHT_ROCKS
+strhelp  = STR_CONFIG_SETTING_HEIGHT_ROCKS_HELPTEXT
+strval   = STR_JUST_COMMA
+
 ;;game_creation.build_public_roads
 [SDT_NULL]
 length   = 1


### PR DESCRIPTION
Pretty simple one here, clear_cmd.cpp is responsible for generating the rocky patches throughout maps. Normally the calculation for how big these patches should be is a flat addition of '5'. In my usual fashion I've turned this into a user controllable setting, 1-255 with the default set to the original hard coded value of 5. 

255 covers a significant portion of the map, which depending on your aesthetic tastes looks ugly as sin; however on a big map with maxheight 127, alpine tree line set at 20 wide with snowline 24, and snow generation controlled by newgrf between 32-127 it looks absolutely gorgeous in OpenGFX landscape (esp. on heightmaps). The big rock patches break up the improved tree generators forests that it covers the entire map with, and provides a real sense of depth to the map.

So-far I've tested settings 1, 5, 255, and various values in between with no ill effects. The rocks while interrupting tree generation are still removable by industry generation, river generation, and everything else in between.

Purely an aesthetic PR but I don't think there's anything wrong with that.
