### PR TITLE
Extra House ID's

### DIFF
--- a/src/house.h
+++ b/src/house.h
@@ -26,7 +26,7 @@ static const HouseID NUM_HOUSES_PER_GRF = 255;    ///< Number of supported house
 
 static const uint HOUSE_NO_CLASS      = 0;
 static const HouseID NEW_HOUSE_OFFSET = 110;    ///< Offset for new houses.
-static const HouseID NUM_HOUSES       = 512;    ///< Total number of houses.
+static const HouseID NUM_HOUSES       = 1024;    ///< Total number of houses.
 static const HouseID INVALID_HOUSE_ID = 0xFFFF;
 
 static const uint HOUSE_NUM_ACCEPTS = 16; ///< Max number of cargoes accepted by a tile

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1803,7 +1803,7 @@ bool AfterLoadGame()
 	}
 
 	/* Check and update house and town values */
-	UpdateHousesAndTowns(gcf_res != GLC_ALL_GOOD);
+	UpdateHousesAndTowns(gcf_res != GLC_ALL_GOOD, true);
 
 	if (IsSavegameVersionBefore(SLV_43)) {
 		for (TileIndex t = 0; t < map_size; t++) {
@@ -3878,6 +3878,15 @@ bool AfterLoadGame()
 		_settings_game.economy.inflation_fixed_dates = !IsSavegameVersionBefore(SLV_GS_INDUSTRY_CONTROL);
 	}
 
+	if (SlXvIsFeatureMissing(XSLFI_MORE_HOUSES)) {
+		for (TileIndex t = 0; t < map_size; t++) {
+			if (IsTileType(t, MP_HOUSE)) {
+				/* Move upper bit of house ID from bit 6 of m3 to bits 6..5 of m3. */
+				SB(_m[t].m3, 5, 2, GB(_m[t].m3, 6, 1));
+			}
+		}
+	}
+
 	InitializeRoadGUI();
 
 	/* This needs to be done after conversion. */
@@ -3988,7 +3997,7 @@ void ReloadNewGRFData()
 	/* Update company statistics. */
 	AfterLoadCompanyStats();
 	/* Check and update house and town values */
-	UpdateHousesAndTowns(true);
+	UpdateHousesAndTowns(true, false);
 	/* Delete news referring to no longer existing entities */
 	DeleteInvalidEngineNews();
 	/* Update livery selection windows */

--- a/src/saveload/extended_ver_sl.cpp
+++ b/src/saveload/extended_ver_sl.cpp
@@ -147,6 +147,7 @@ const SlxiSubChunkInfo _sl_xv_sub_chunk_infos[] = {
 	{ XSLFI_REALISTIC_TRAIN_BRAKING,XSCF_NULL,                1,   1, "realistic_train_braking",   nullptr, nullptr, "VLKA"         },
 	{ XSLFI_INFLATION_FIXED_DATES,  XSCF_IGNORABLE_ALL,       1,   1, "inflation_fixed_dates",     nullptr, nullptr, nullptr        },
 	{ XSLFI_WATER_FLOODING,         XSCF_NULL,                1,   1, "water_flooding",            nullptr, nullptr, nullptr        },
+	{ XSLFI_MORE_HOUSES,            XSCF_NULL,                1,   1, "more_houses",               nullptr, nullptr, nullptr        },
 	{ XSLFI_NULL, XSCF_NULL, 0, 0, nullptr, nullptr, nullptr, nullptr },// This is the end marker
 };
 

--- a/src/saveload/extended_ver_sl.h
+++ b/src/saveload/extended_ver_sl.h
@@ -101,6 +101,7 @@ enum SlXvFeatureIndex {
 	XSLFI_REALISTIC_TRAIN_BRAKING,                ///< Realistic train braking
 	XSLFI_INFLATION_FIXED_DATES,                  ///< Inflation is applied between fixed dates
 	XSLFI_WATER_FLOODING,                         ///< Water flooding map bit
+	XSLFI_MORE_HOUSES,                            ///< More house types
 
 	XSLFI_RIFF_HEADER_60_BIT,                     ///< Size field in RIFF chunk header is 60 bit
 	XSLFI_HEIGHT_8_BIT,                           ///< Map tile height is 8 bit instead of 4 bit, but savegame version may be before this became true in trunk

--- a/src/saveload/saveload_internal.h
+++ b/src/saveload/saveload_internal.h
@@ -36,7 +36,7 @@ void AfterLoadStoryBook();
 void AfterLoadLinkGraphs();
 void AfterLoadCompanyStats();
 void AfterLoadTraceRestrict();
-void UpdateHousesAndTowns(bool cargo_update_required);
+void UpdateHousesAndTowns(bool cargo_update_required, bool old_map_position);
 
 void UpdateOldAircraft();
 

--- a/src/town_map.h
+++ b/src/town_map.h
@@ -47,7 +47,7 @@ static inline void SetTownIndex(TileIndex t, TownID index)
 static inline HouseID GetCleanHouseType(TileIndex t)
 {
 	assert_tile(IsTileType(t, MP_HOUSE), t);
-	return _m[t].m4 | (GB(_m[t].m3, 6, 1) << 8);
+	return _m[t].m4 | (GB(_m[t].m3, 5, 2) << 8);
 }
 
 /**
@@ -71,7 +71,7 @@ static inline void SetHouseType(TileIndex t, HouseID house_id)
 {
 	assert_tile(IsTileType(t, MP_HOUSE), t);
 	_m[t].m4 = GB(house_id, 0, 8);
-	SB(_m[t].m3, 6, 1, GB(house_id, 8, 1));
+	SB(_m[t].m3, 5, 2, GB(house_id, 8, 2));
 }
 
 /**


### PR DESCRIPTION
Use an extra unused 5th bit in m3 to boost the max number of house types from 512 to 1024. So-far everything works, construction stages and animations appear unaffected by my hubris.

I'm absolutely certain this has to be more difficult than this but I haven't managed to break it yet even loading several heavyweight .GRF's simultaneously; JPSet Buildings, DPRK Buildings, TTRS, Swedish Houses, NABS and Snow-Aware vanilla TTD buildings.

Out of scope: Changing the max amount of newhouses in a single .grf.