### PR TITLE
Shows payment based on average transit speed

### DIFF
--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -1048,10 +1048,13 @@ struct PaymentRatesGraphWindow : BaseGraphWindow {
 
 		int i = 0;
 		const CargoSpec *cs;
+		const float factor = 200.0f * 28.57f * 0.4f;
+
 		FOR_ALL_SORTED_STANDARD_CARGOSPECS(cs) {
 			this->colours[i] = cs->legend_colour;
-			for (uint j = 0; j != 20; j++) {
-				this->cost[i][j] = GetTransportedGoodsIncome(10, 20, j * 4 + 4, cs->Index());
+			for (int j = 0; j != 20; j++) {
+				const byte ctt = static_cast<byte>(factor / ((static_cast<float>(j) + 1) * 10.0f));
+				this->cost[i][j] = GetTransportedGoodsIncome(1, 200, ctt, cs->Index());
 			}
 			i++;
 		}

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -598,7 +598,7 @@ STR_GRAPH_COMPANY_PERFORMANCE_RATINGS_CAPTION                   :{WHITE}Company 
 STR_GRAPH_COMPANY_VALUES_CAPTION                                :{WHITE}Company values
 
 STR_GRAPH_CARGO_PAYMENT_RATES_CAPTION                           :{WHITE}Cargo Payment Rates
-STR_GRAPH_CARGO_PAYMENT_RATES_X_LABEL                           :{TINY_FONT}{BLACK}Days in transit
+STR_GRAPH_CARGO_PAYMENT_RATES_X_LABEL                           :{TINY_FONT}{BLACK}Average transit speed (km/h)
 STR_GRAPH_CARGO_PAYMENT_RATES_TITLE                             :{TINY_FONT}{BLACK}Payment for delivering 10 units (or 10,000 litres) of cargo a distance of 20 squares
 STR_GRAPH_CARGO_ENABLE_ALL                                      :{TINY_FONT}{BLACK}Enable all
 STR_GRAPH_CARGO_DISABLE_ALL                                     :{TINY_FONT}{BLACK}Disable all


### PR DESCRIPTION
Prior to this change, the charts were pretty useless. They indicated at most what cargos were speed sensitive and which ones were not.

This change lets the graph show the average transit speed to profit mapping. With this graph it becomes obvious after exactly what speed any further speed increase brings no further profit. This makes train selection way easier.