### PR TITLE
Train speed adaptation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -479,6 +479,7 @@ add_files(
     train.h
     train_cmd.cpp
     train_gui.cpp
+    train_speed_adaptation.h
     transparency.h
     transparency_gui.cpp
     transparency_gui.h

--- a/src/date.cpp
+++ b/src/date.cpp
@@ -282,7 +282,7 @@ static void OnNewDay()
 	if (!_settings_time.time_in_minutes || _settings_client.gui.date_with_time > 0) {
 		SetWindowWidgetDirty(WC_STATUS_BAR, 0, WID_S_LEFT);
 	}
-	EnginesDailyLoop();	
+	EnginesDailyLoop();
 	ClearOutOfDateSignalSpeedRestrictions();
 
 	/* Refresh after possible snowline change */

--- a/src/date.cpp
+++ b/src/date.cpp
@@ -39,6 +39,8 @@ YearMonthDay _game_load_cur_date_ymd;
 DateFract _game_load_date_fract;
 uint8 _game_load_tick_skip_counter;
 
+extern void ClearOutOfDateSignalSpeedRestrictions();
+
 /**
  * Set the date.
  * @param date  New date
@@ -280,7 +282,8 @@ static void OnNewDay()
 	if (!_settings_time.time_in_minutes || _settings_client.gui.date_with_time > 0) {
 		SetWindowWidgetDirty(WC_STATUS_BAR, 0, WID_S_LEFT);
 	}
-	EnginesDailyLoop();
+	EnginesDailyLoop();	
+	ClearOutOfDateSignalSpeedRestrictions();
 
 	/* Refresh after possible snowline change */
 	SetWindowClassesDirty(WC_TOWN_VIEW);

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1811,8 +1811,8 @@ STR_CONFIG_SETTING_NOSERVICE                                    :Disable servici
 STR_CONFIG_SETTING_NOSERVICE_HELPTEXT                           :When enabled, vehicles do not get serviced if they cannot break down
 STR_CONFIG_SETTING_WAGONSPEEDLIMITS                             :Enable wagon speed limits: {STRING2}
 STR_CONFIG_SETTING_WAGONSPEEDLIMITS_HELPTEXT                    :When enabled, also use speed limits of wagons for deciding the maximum speed of a train
-STR_CONFIG_SETTING_TRAIN_SPEED_ADAPTION                         :Enable train speed adaption: {STRING2}
-STR_CONFIG_SETTING_TRAIN_SPEED_ADAPTION_HELPTEXT                :If enabled, faster trains behind slower trains adjust their speed.
+STR_CONFIG_SETTING_TRAIN_SPEED_ADAPTATION                       :Enable train speed adaptation: {STRING2}
+STR_CONFIG_SETTING_TRAIN_SPEED_ADAPTATION_HELPTEXT              :When enabled, faster trains adjust their speed to match slower trains in front.
 STR_CONFIG_SETTING_SLOW_ROAD_VEHICLES_IN_CURVES                 :Road vehicles slow down in curves: {STRING2}
 STR_CONFIG_SETTING_SLOW_ROAD_VEHICLES_IN_CURVES_HELPTEXT        :When enabled, road vehicles slow down in curves. (Only with realistic acceleration)
 STR_CONFIG_SETTING_DISABLE_ELRAILS                              :Disable electric rails: {STRING2}

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1811,6 +1811,8 @@ STR_CONFIG_SETTING_NOSERVICE                                    :Disable servici
 STR_CONFIG_SETTING_NOSERVICE_HELPTEXT                           :When enabled, vehicles do not get serviced if they cannot break down
 STR_CONFIG_SETTING_WAGONSPEEDLIMITS                             :Enable wagon speed limits: {STRING2}
 STR_CONFIG_SETTING_WAGONSPEEDLIMITS_HELPTEXT                    :When enabled, also use speed limits of wagons for deciding the maximum speed of a train
+STR_CONFIG_SETTING_TRAIN_SPEED_ADAPTION                         :Enable train speed adaption: {STRING2}
+STR_CONFIG_SETTING_TRAIN_SPEED_ADAPTION_HELPTEXT                :If enabled, faster trains behind slower trains adjust their speed.
 STR_CONFIG_SETTING_SLOW_ROAD_VEHICLES_IN_CURVES                 :Road vehicles slow down in curves: {STRING2}
 STR_CONFIG_SETTING_SLOW_ROAD_VEHICLES_IN_CURVES_HELPTEXT        :When enabled, road vehicles slow down in curves. (Only with realistic acceleration)
 STR_CONFIG_SETTING_DISABLE_ELRAILS                              :Disable electric rails: {STRING2}

--- a/src/lang/german.txt
+++ b/src/lang/german.txt
@@ -1737,6 +1737,10 @@ STR_CONFIG_SETTING_NOSERVICE                                    :Wartung deaktiv
 STR_CONFIG_SETTING_NOSERVICE_HELPTEXT                           :Schicke Fahrzeuge nicht zur Wartung, wenn Pannen ausgeschaltet sind
 STR_CONFIG_SETTING_WAGONSPEEDLIMITS                             :Berücksichtige Waggonhöchstgeschwindigkeit: {STRING}
 STR_CONFIG_SETTING_WAGONSPEEDLIMITS_HELPTEXT                    :Begrenze die Höchstgeschwindigkeit eines Zuges durch die jeweiligen Höchstgeschwindigkeiten der mitgeführten Waggons
+STR_CONFIG_SETTING_TRAIN_SPEED_ADAPTION                         :Zuggeschwindigkeitsanpassung aktivieren: {STRING2}
+STR_CONFIG_SETTING_TRAIN_SPEED_ADAPTION_HELPTEXT                :Wenn aktiviert, passen schnellere Züge hinter langsameren Zügen ihre Geschwindigkeit an.
+STR_CONFIG_SETTING_SLOW_ROAD_VEHICLES_IN_CURVES                 :Straßenfahrzeuge werden in Kurven langsamer: {STRING2}
+STR_CONFIG_SETTING_SLOW_ROAD_VEHICLES_IN_CURVES_HELPTEXT        :Wenn aktiviert, verlangsamen Straßenfahrzeuge in Kurven. (Nur im Beschleunigungsmodell „Realistisch“)
 STR_CONFIG_SETTING_DISABLE_ELRAILS                              :Deaktiviere elektrifizierte Strecken: {STRING}
 STR_CONFIG_SETTING_DISABLE_ELRAILS_HELPTEXT                     :Erlaube Elektrolokomotiven das Fahren auf nicht elektrifizierten Gleisen
 

--- a/src/lang/german.txt
+++ b/src/lang/german.txt
@@ -1737,8 +1737,8 @@ STR_CONFIG_SETTING_NOSERVICE                                    :Wartung deaktiv
 STR_CONFIG_SETTING_NOSERVICE_HELPTEXT                           :Schicke Fahrzeuge nicht zur Wartung, wenn Pannen ausgeschaltet sind
 STR_CONFIG_SETTING_WAGONSPEEDLIMITS                             :Berücksichtige Waggonhöchstgeschwindigkeit: {STRING}
 STR_CONFIG_SETTING_WAGONSPEEDLIMITS_HELPTEXT                    :Begrenze die Höchstgeschwindigkeit eines Zuges durch die jeweiligen Höchstgeschwindigkeiten der mitgeführten Waggons
-STR_CONFIG_SETTING_TRAIN_SPEED_ADAPTION                         :Zuggeschwindigkeitsanpassung aktivieren: {STRING}
-STR_CONFIG_SETTING_TRAIN_SPEED_ADAPTION_HELPTEXT                :Wenn aktiviert, passen schnellere Züge hinter langsameren Zügen ihre Geschwindigkeit an.
+STR_CONFIG_SETTING_TRAIN_SPEED_ADAPTATION                       :Zuggeschwindigkeitsanpassung aktivieren: {STRING}
+STR_CONFIG_SETTING_TRAIN_SPEED_ADAPTATION_HELPTEXT              :Wenn aktiviert, passen schnellere Züge hinter langsameren Zügen ihre Geschwindigkeit an.
 STR_CONFIG_SETTING_SLOW_ROAD_VEHICLES_IN_CURVES                 :Straßenfahrzeuge werden in Kurven langsamer: {STRING}
 STR_CONFIG_SETTING_SLOW_ROAD_VEHICLES_IN_CURVES_HELPTEXT        :Wenn aktiviert, verlangsamen Straßenfahrzeuge in Kurven. (Nur im Beschleunigungsmodell „Realistisch“)
 STR_CONFIG_SETTING_DISABLE_ELRAILS                              :Deaktiviere elektrifizierte Strecken: {STRING}

--- a/src/lang/german.txt
+++ b/src/lang/german.txt
@@ -1737,9 +1737,9 @@ STR_CONFIG_SETTING_NOSERVICE                                    :Wartung deaktiv
 STR_CONFIG_SETTING_NOSERVICE_HELPTEXT                           :Schicke Fahrzeuge nicht zur Wartung, wenn Pannen ausgeschaltet sind
 STR_CONFIG_SETTING_WAGONSPEEDLIMITS                             :Berücksichtige Waggonhöchstgeschwindigkeit: {STRING}
 STR_CONFIG_SETTING_WAGONSPEEDLIMITS_HELPTEXT                    :Begrenze die Höchstgeschwindigkeit eines Zuges durch die jeweiligen Höchstgeschwindigkeiten der mitgeführten Waggons
-STR_CONFIG_SETTING_TRAIN_SPEED_ADAPTION                         :Zuggeschwindigkeitsanpassung aktivieren: {STRING2}
+STR_CONFIG_SETTING_TRAIN_SPEED_ADAPTION                         :Zuggeschwindigkeitsanpassung aktivieren: {STRING}
 STR_CONFIG_SETTING_TRAIN_SPEED_ADAPTION_HELPTEXT                :Wenn aktiviert, passen schnellere Züge hinter langsameren Zügen ihre Geschwindigkeit an.
-STR_CONFIG_SETTING_SLOW_ROAD_VEHICLES_IN_CURVES                 :Straßenfahrzeuge werden in Kurven langsamer: {STRING2}
+STR_CONFIG_SETTING_SLOW_ROAD_VEHICLES_IN_CURVES                 :Straßenfahrzeuge werden in Kurven langsamer: {STRING}
 STR_CONFIG_SETTING_SLOW_ROAD_VEHICLES_IN_CURVES_HELPTEXT        :Wenn aktiviert, verlangsamen Straßenfahrzeuge in Kurven. (Nur im Beschleunigungsmodell „Realistisch“)
 STR_CONFIG_SETTING_DISABLE_ELRAILS                              :Deaktiviere elektrifizierte Strecken: {STRING}
 STR_CONFIG_SETTING_DISABLE_ELRAILS_HELPTEXT                     :Erlaube Elektrolokomotiven das Fahren auf nicht elektrifizierten Gleisen

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -118,6 +118,7 @@ void InitializeGame(uint size_x, uint size_y, bool reset_date, bool reset_settin
 
 	FreeSignalPrograms();
 	FreeSignalDependencies();
+
 	ClearAllSignalSpeedRestrictions();
 
 	ClearZoningCaches();

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -43,6 +43,7 @@
 
 
 extern TileIndex _cur_tileloop_tile;
+extern void ClearAllSignalSpeedRestrictions();
 extern void MakeNewgameSettingsLive();
 
 void InitializeSound();
@@ -116,7 +117,8 @@ void InitializeGame(uint size_x, uint size_y, bool reset_date, bool reset_settin
 	RebuildViewportKdtree();
 
 	FreeSignalPrograms();
-	FreeSignalDependencies();
+	FreeSignalDependencies();	
+	ClearAllSignalSpeedRestrictions();
 
 	ClearZoningCaches();
 	IntialiseOrderDestinationRefcountMap();

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -117,7 +117,7 @@ void InitializeGame(uint size_x, uint size_y, bool reset_date, bool reset_settin
 	RebuildViewportKdtree();
 
 	FreeSignalPrograms();
-	FreeSignalDependencies();	
+	FreeSignalDependencies();
 	ClearAllSignalSpeedRestrictions();
 
 	ClearZoningCaches();

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -439,6 +439,9 @@ static void ShutdownGame()
 	FreeSignalPrograms();
 	FreeSignalDependencies();
 
+	extern void ClearAllSignalSpeedRestrictions();
+	ClearAllSignalSpeedRestrictions();
+
 	ClearZoningCaches();
 	ClearOrderDestinationRefcountMap();
 

--- a/src/saveload/CMakeLists.txt
+++ b/src/saveload/CMakeLists.txt
@@ -48,6 +48,7 @@ add_files(
     tbtr_template_veh_sl.cpp
     town_sl.cpp
     tracerestrict_sl.cpp
+    train_speed_adaptation.cpp
     tunnel_sl.cpp
     vehicle_sl.cpp
     waypoint_sl.cpp

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -938,6 +938,10 @@ bool AfterLoadGame()
 		_settings_game.vehicle.train_braking_model = TBM_ORIGINAL;
 	}
 
+	if (SlXvIsFeatureMissing(XSLFI_TRAIN_SPEED_ADAPTATION)) {
+		_settings_game.vehicle.train_speed_adaptation = false;
+	}
+
 	AfterLoadEngines();
 
 	/* Update all vehicles */

--- a/src/saveload/extended_ver_sl.cpp
+++ b/src/saveload/extended_ver_sl.cpp
@@ -151,6 +151,7 @@ const SlxiSubChunkInfo _sl_xv_sub_chunk_infos[] = {
 	{ XSLFI_WATER_FLOODING,         XSCF_NULL,                2,   2, "water_flooding",            nullptr, nullptr, nullptr        },
 	{ XSLFI_MORE_HOUSES,            XSCF_NULL,                2,   2, "more_houses",               nullptr, nullptr, nullptr        },
 	{ XSLFI_CUSTOM_TOWN_ZONE,       XSCF_IGNORABLE_UNKNOWN,   1,   1, "custom_town_zone",          nullptr, nullptr, nullptr        },
+	{ XSLFI_TRAIN_SPEED_ADAPTATION, XSCF_NULL,                1,   1, "train_speed_adaptation",    nullptr, nullptr, "TSAS"         },
 	{ XSLFI_NULL, XSCF_NULL, 0, 0, nullptr, nullptr, nullptr, nullptr },// This is the end marker
 };
 

--- a/src/saveload/extended_ver_sl.h
+++ b/src/saveload/extended_ver_sl.h
@@ -105,6 +105,7 @@ enum SlXvFeatureIndex {
 	XSLFI_WATER_FLOODING,                         ///< Water flooding map bit
 	XSLFI_MORE_HOUSES,                            ///< More house types
 	XSLFI_CUSTOM_TOWN_ZONE,                       ///< Custom town zones
+	XSLFI_TRAIN_SPEED_ADAPTATION,                 ///< Train speed adaptation
 
 	XSLFI_RIFF_HEADER_60_BIT,                     ///< Size field in RIFF chunk header is 60 bit
 	XSLFI_HEIGHT_8_BIT,                           ///< Map tile height is 8 bit instead of 4 bit, but savegame version may be before this became true in trunk

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -288,6 +288,7 @@ extern const ChunkHandler _template_replacement_chunk_handlers[];
 extern const ChunkHandler _template_vehicle_chunk_handlers[];
 extern const ChunkHandler _bridge_signal_chunk_handlers[];
 extern const ChunkHandler _tunnel_chunk_handlers[];
+extern const ChunkHandler _train_speed_adaptation_chunk_handlers[];
 extern const ChunkHandler _debug_chunk_handlers[];
 
 /** Array of all chunks in a savegame, \c nullptr terminated. */
@@ -333,6 +334,7 @@ static const ChunkHandler * const _chunk_handlers[] = {
 	_template_vehicle_chunk_handlers,
 	_bridge_signal_chunk_handlers,
 	_tunnel_chunk_handlers,
+	_train_speed_adaptation_chunk_handlers,
 	_debug_chunk_handlers,
 	nullptr,
 };

--- a/src/saveload/train_speed_adaptation.cpp
+++ b/src/saveload/train_speed_adaptation.cpp
@@ -1,0 +1,51 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file train_speed_adaptation.cpp Code handling saving and loading of data for train speed adaptation */
+
+#include "../stdafx.h"
+#include "../train_speed_adaptation.h"
+#include "saveload.h"
+
+using SignalSpeedType = std::pair<const SignalSpeedKey, SignalSpeedValue>;
+
+static const SaveLoad _train_speed_adaptation_map_desc[] = {
+	SLE_VAR(SignalSpeedType, first.signal_track,           SLE_UINT8),
+	SLE_VAR(SignalSpeedType, first.last_passing_train_dir, SLE_UINT8),
+	SLE_VAR(SignalSpeedType, second.train_speed,           SLE_UINT16),
+	SLE_VAR(SignalSpeedType, second.time_stamp,            SLE_UINT64),
+	SLE_END()
+};
+
+static void Load_TSAS()
+{
+	int index;
+	SignalSpeedType data;
+	while ((index = SlIterateArray()) != -1) {
+		const_cast<SignalSpeedKey &>(data.first).signal_tile = index;
+		SlObject(&data, _train_speed_adaptation_map_desc);
+		_signal_speeds.insert(data);
+	}
+}
+
+static void RealSave_TSAS(SignalSpeedType *data)
+{
+	SlObject(data, _train_speed_adaptation_map_desc);
+}
+
+static void Save_TSAS()
+{
+	for (auto &it : _signal_speeds) {
+		SlSetArrayIndex(it.first.signal_tile);
+		SignalSpeedType *data = &it;
+		SlAutolength((AutolengthProc*) RealSave_TSAS, data);
+	}
+}
+
+extern const ChunkHandler _train_speed_adaptation_chunk_handlers[] = {
+	{ 'TSAS', Save_TSAS, Load_TSAS, nullptr, nullptr, CH_SPARSE_ARRAY | CH_LAST},
+};

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -807,6 +807,7 @@ const SaveLoad *GetVehicleDescription(VehicleType vt)
 		SLE_CONDNULL(11, SLV_2, SLV_144), // old reserved space
 		SLE_CONDVAR_X(Train, reverse_distance,    SLE_UINT16,         SL_MIN_VERSION, SL_MAX_VERSION, SlXvFeatureTest(XSLFTO_AND, XSLFI_REVERSE_AT_WAYPOINT)),
 		SLE_CONDVAR_X(Train, speed_restriction,   SLE_UINT16,         SL_MIN_VERSION, SL_MAX_VERSION, SlXvFeatureTest(XSLFTO_AND, XSLFI_SPEED_RESTRICTION)),
+		SLE_CONDVAR_X(Train, signal_speed_restriction, SLE_UINT16,    SL_MIN_VERSION, SL_MAX_VERSION, SlXvFeatureTest(XSLFTO_AND, XSLFI_TRAIN_SPEED_ADAPTATION)),
 		SLE_CONDVAR_X(Train, critical_breakdown_count, SLE_UINT8,     SL_MIN_VERSION, SL_MAX_VERSION, SlXvFeatureTest(XSLFTO_AND, XSLFI_IMPROVED_BREAKDOWNS, 2)),
 
 		     SLE_END()

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1541,6 +1541,15 @@ static bool PublicRoadsSettingChange(int32 p1) {
 	return true;
 }
 
+static bool TrainSpeedAdaptionChanged(int32 p1) {
+	extern void ClearAllSignalSpeedRestrictions();
+	ClearAllSignalSpeedRestrictions();
+	for (Train *t : Train::Iterate()) {
+		t->signal_speed_restriction = 0;
+	}
+	return true;
+}
+
 /** Checks if any settings are set to incorrect values, and sets them to correct values in that case. */
 static void ValidateSettings()
 {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1793,7 +1793,12 @@ static bool ImprovedBreakdownsSettingChanged(int32 p1)
 
 static bool DayLengthChanged(int32 p1)
 {
+	const DateTicksScaled old_scaled_date_ticks = _scaled_date_ticks;
 	SetScaledTickVariables();
+
+	extern void AdjustAllSignalSpeedRestrictionTickValues(DateTicksScaled delta);
+	AdjustAllSignalSpeedRestrictionTickValues(_scaled_date_ticks - old_scaled_date_ticks);
+
 	MarkWholeScreenDirty();
 	return true;
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1541,7 +1541,7 @@ static bool PublicRoadsSettingChange(int32 p1) {
 	return true;
 }
 
-static bool TrainSpeedAdaptionChanged(int32 p1) {
+static bool TrainSpeedAdaptationChanged(int32 p1) {
 	extern void ClearAllSignalSpeedRestrictions();
 	ClearAllSignalSpeedRestrictions();
 	for (Train *t : Train::Iterate()) {

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1923,7 +1923,7 @@ static SettingsContainer &GetSettingsTree()
 				physics->Add(new SettingEntry("vehicle.train_braking_model"));
 				physics->Add(new SettingEntry("vehicle.train_slope_steepness"));
 				physics->Add(new SettingEntry("vehicle.wagon_speed_limits"));
-				physics->Add(new SettingEntry("vehicle.train_speed_adaption"));
+				physics->Add(new SettingEntry("vehicle.train_speed_adaptation"));
 				physics->Add(new SettingEntry("vehicle.freight_trains"));
 				physics->Add(new SettingEntry("vehicle.roadveh_acceleration_model"));
 				physics->Add(new SettingEntry("vehicle.roadveh_slope_steepness"));

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1923,6 +1923,7 @@ static SettingsContainer &GetSettingsTree()
 				physics->Add(new SettingEntry("vehicle.train_braking_model"));
 				physics->Add(new SettingEntry("vehicle.train_slope_steepness"));
 				physics->Add(new SettingEntry("vehicle.wagon_speed_limits"));
+				physics->Add(new SettingEntry("vehicle.train_speed_adaption"));
 				physics->Add(new SettingEntry("vehicle.freight_trains"));
 				physics->Add(new SettingEntry("vehicle.roadveh_acceleration_model"));
 				physics->Add(new SettingEntry("vehicle.roadveh_slope_steepness"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -572,7 +572,7 @@ struct VehicleSettings {
 	uint8  train_slope_steepness;            ///< Steepness of hills for trains when using realistic acceleration
 	uint8  roadveh_slope_steepness;          ///< Steepness of hills for road vehicles when using realistic acceleration
 	bool   wagon_speed_limits;               ///< enable wagon speed limits
-	bool   train_speed_adaption;             ///< Faster trains behind slower trains slow down
+	bool   train_speed_adaptation;           ///< Faster trains slow down when behind slower trains
 	bool   slow_road_vehicles_in_curves;     ///< Road vehicles slow down in curves.
 	bool   disable_elrails;                  ///< when true, the elrails are disabled
 	UnitID max_trains;                       ///< max trains in game per company

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -572,6 +572,7 @@ struct VehicleSettings {
 	uint8  train_slope_steepness;            ///< Steepness of hills for trains when using realistic acceleration
 	uint8  roadveh_slope_steepness;          ///< Steepness of hills for road vehicles when using realistic acceleration
 	bool   wagon_speed_limits;               ///< enable wagon speed limits
+	bool   train_speed_adaption;             ///< Faster trains behind slower trains slow down
 	bool   slow_road_vehicles_in_curves;     ///< Road vehicles slow down in curves.
 	bool   disable_elrails;                  ///< when true, the elrails are disabled
 	UnitID max_trains;                       ///< max trains in game per company

--- a/src/table/newgrf_debug_data.h
+++ b/src/table/newgrf_debug_data.h
@@ -162,8 +162,11 @@ class NIHVehicle : public NIHelper {
 			seprintf(buffer, lastof(buffer), "  T cache: veh weight: %u, user data: %u, curve speed: %u",
 					t->tcache.cached_veh_weight, t->tcache.user_def_data, t->tcache.cached_max_curve_speed);
 			print(buffer);
-			seprintf(buffer, lastof(buffer), "  Wait counter: %u, rev distance: %u, TBSN: %u, speed restriction: %u",
-					t->wait_counter, t->reverse_distance, t->tunnel_bridge_signal_num, t->speed_restriction);
+			seprintf(buffer, lastof(buffer), "  Wait counter: %u, rev distance: %u, TBSN: %u",
+					t->wait_counter, t->reverse_distance, t->tunnel_bridge_signal_num);
+			print(buffer);
+			seprintf(buffer, lastof(buffer), "  Speed restriction: %u, signal speed restriction (ATC): %u",
+					t->speed_restriction, t->signal_speed_restriction);
 			print(buffer);
 			seprintf(buffer, lastof(buffer), "  Railtype: %u, compatible_railtypes: 0x" OTTD_PRINTFHEX64,
 					t->railtype, t->compatible_railtypes);

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -1676,9 +1676,18 @@ cat      = SC_BASIC
 patxname = ""slow_road_vehicles_in_curves.vehicle.slow_road_vehicles_in_curves""
 
 ;; vehicle.train_speed_adaption
-[SDT_NULL]
-length   = 1
+[SDT_XREF]
 extver   = SlXvFeatureTest(XSLFTO_AND, XSLFI_JOKERPP)
+xref     = ""vehicle.train_speed_adaption""
+
+[SDT_BOOL]
+base     = GameSettings
+var      = vehicle.train_speed_adaption
+def      = true
+str      = STR_CONFIG_SETTING_TRAIN_SPEED_ADAPTION
+strhelp  = STR_CONFIG_SETTING_TRAIN_SPEED_ADAPTION_HELPTEXT
+cat      = SC_EXPERT
+patxname = ""train_speed_adaption.vehicle.train_speed_adaption""
 
 [SDT_BOOL]
 base     = GameSettings

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -64,7 +64,7 @@ static bool ClimateThresholdModeChanged(int32 p1);
 static bool VelocityUnitsChanged(int32 p1);
 static bool ChangeTrackTypeSortMode(int32 p1);
 static bool PublicRoadsSettingChange(int32 p1);
-static bool TrainSpeedAdaptionChanged(int32 p1);
+static bool TrainSpeedAdaptationChanged(int32 p1);
 
 static bool UpdateClientName(int32 p1);
 static bool UpdateServerPassword(int32 p1);
@@ -1676,20 +1676,19 @@ strhelp  = STR_CONFIG_SETTING_SLOW_ROAD_VEHICLES_IN_CURVES_HELPTEXT
 cat      = SC_BASIC
 patxname = ""slow_road_vehicles_in_curves.vehicle.slow_road_vehicles_in_curves""
 
-;; vehicle.train_speed_adaption
 [SDT_XREF]
 extver   = SlXvFeatureTest(XSLFTO_AND, XSLFI_JOKERPP)
-xref     = ""vehicle.train_speed_adaption""
+xref     = ""vehicle.train_speed_adaptation""
 
 [SDT_BOOL]
 base     = GameSettings
-var      = vehicle.train_speed_adaption
+var      = vehicle.train_speed_adaptation
 def      = true
-str      = STR_CONFIG_SETTING_TRAIN_SPEED_ADAPTION
-strhelp  = STR_CONFIG_SETTING_TRAIN_SPEED_ADAPTION_HELPTEXT
+str      = STR_CONFIG_SETTING_TRAIN_SPEED_ADAPTATION
+strhelp  = STR_CONFIG_SETTING_TRAIN_SPEED_ADAPTATION_HELPTEXT
 cat      = SC_EXPERT
-proc     = TrainSpeedAdaptionChanged
-patxname = ""train_speed_adaption.vehicle.train_speed_adaption""
+proc     = TrainSpeedAdaptationChanged
+patxname = ""train_speed_adaptation.vehicle.train_speed_adaptation""
 
 [SDT_BOOL]
 base     = GameSettings

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -64,6 +64,7 @@ static bool ClimateThresholdModeChanged(int32 p1);
 static bool VelocityUnitsChanged(int32 p1);
 static bool ChangeTrackTypeSortMode(int32 p1);
 static bool PublicRoadsSettingChange(int32 p1);
+static bool TrainSpeedAdaptionChanged(int32 p1);
 
 static bool UpdateClientName(int32 p1);
 static bool UpdateServerPassword(int32 p1);
@@ -1687,6 +1688,7 @@ def      = true
 str      = STR_CONFIG_SETTING_TRAIN_SPEED_ADAPTION
 strhelp  = STR_CONFIG_SETTING_TRAIN_SPEED_ADAPTION_HELPTEXT
 cat      = SC_EXPERT
+proc     = TrainSpeedAdaptionChanged
 patxname = ""train_speed_adaption.vehicle.train_speed_adaption""
 
 [SDT_BOOL]

--- a/src/train.h
+++ b/src/train.h
@@ -190,6 +190,7 @@ struct Train FINAL : public GroundVehicle<Train, VEH_TRAIN> {
 	};
 
 private:
+	int GetAtcMaxSpeed(int current_max_speed) const;
 	MaxSpeedInfo GetCurrentMaxSpeedInfoInternal(bool update_state) const;
 
 public:

--- a/src/train.h
+++ b/src/train.h
@@ -191,7 +191,6 @@ struct Train FINAL : public GroundVehicle<Train, VEH_TRAIN> {
 	};
 
 private:
-	int GetAtcMaxSpeed() const;
 	MaxSpeedInfo GetCurrentMaxSpeedInfoInternal(bool update_state) const;
 
 public:

--- a/src/train.h
+++ b/src/train.h
@@ -147,6 +147,7 @@ struct Train FINAL : public GroundVehicle<Train, VEH_TRAIN> {
 	uint16 reverse_distance;
 	uint16 tunnel_bridge_signal_num;
 	uint16 speed_restriction;
+	uint16 signal_speed_restriction;
 
 	/** We don't want GCC to zero our struct! It already is zeroed and has an index! */
 	Train() : GroundVehicleBase() {}
@@ -190,7 +191,7 @@ struct Train FINAL : public GroundVehicle<Train, VEH_TRAIN> {
 	};
 
 private:
-	int GetAtcMaxSpeed(int current_max_speed) const;
+	int GetAtcMaxSpeed() const;
 	MaxSpeedInfo GetCurrentMaxSpeedInfoInternal(bool update_state) const;
 
 public:

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -102,9 +102,8 @@ static DateTicksScaled GetSpeedRestrictionTimeout(const Train *t)
 	const int64 look_ahead_distance = 16; // In tiles
 	const int64 velocity = std::max<int64>(25, t->cur_speed);
 
-	// This is a guess. I cannot figure out how the game actually calculates ticks_per_tile.
-	// If anybody has the correct value here, let me know.
-	const int64 ticks_per_tile = 2232 / velocity;
+	// This assumes travel along the X or Y map axis, not diagonally. See GetAdvanceDistance, GetAdvanceSpeed.
+	const int64 ticks_per_tile = (192 * 16 * 4 / 3) / velocity;
 
 	const int64 ticks = ticks_per_tile * look_ahead_distance;
 

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -99,8 +99,8 @@ static bool CheckTrainStayInWormHolePathReserve(Train *t, TileIndex tile);
  *  at the current position of the train is going to be invalid */
 static DateTicksScaled GetSpeedRestrictionTimeout(const Train *t)
 {
-	const int64 look_ahead_distance = 16; // In tiles
 	const int64 velocity = std::max<int64>(25, t->cur_speed);
+	const int64 look_ahead_distance = Clamp(t->cur_speed / 8, 6, 16); // In tiles, varying between 6 and 16 depending on current speed
 
 	// This assumes travel along the X or Y map axis, not diagonally. See GetAdvanceDistance, GetAdvanceSpeed.
 	const int64 ticks_per_tile = (192 * 16 * 4 / 3) / velocity;

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -1030,7 +1030,7 @@ static void AdvanceLookAheadPosition(Train *v)
  */
 int32 Train::GetAtcMaxSpeed() const
 {
-	if (!(this->vehstatus & VS_CRASHED) && _settings_game.vehicle.train_speed_adaption && this->signal_speed_restriction != 0) {
+	if (!(this->vehstatus & VS_CRASHED) && this->signal_speed_restriction != 0) {
 		return std::max<int32>(25, this->signal_speed_restriction);
 	}
 
@@ -1047,7 +1047,7 @@ Train::MaxSpeedInfo Train::GetCurrentMaxSpeedInfoInternal(bool update_state) con
 			this->gcache.cached_max_track_speed :
 			std::min<int>(this->tcache.cached_max_curve_speed, this->gcache.cached_max_track_speed);
 
-	max_speed = std::min<int>(max_speed, GetAtcMaxSpeed());
+	if (_settings_game.vehicle.train_speed_adaption) max_speed = std::min<int>(max_speed, GetAtcMaxSpeed());
 
 	if (this->current_order.IsType(OT_LOADING_ADVANCE)) max_speed = std::min(max_speed, 15);
 
@@ -5592,7 +5592,7 @@ bool TrainController(Train *v, Vehicle *nomove, bool reverse)
 		if (update_signals_crossing) {
 
 			if (v->IsFrontEngine()) {
-				if (IsTileType(gp.old_tile, MP_RAILWAY) && HasSignals(gp.old_tile)) {
+				if (_settings_game.vehicle.train_speed_adaption && IsTileType(gp.old_tile, MP_RAILWAY) && HasSignals(gp.old_tile)) {
 					const TrackdirBits rev_tracks = TrackBitsToTrackdirBits(GetTrackBits(gp.old_tile)) & DiagdirReachesTrackdirs(ReverseDiagDir(enterdir));
 					const Trackdir rev_trackdir = FindFirstTrackdir(rev_tracks);
 					const Track track = TrackdirToTrack(rev_trackdir);
@@ -5658,16 +5658,18 @@ bool TrainController(Train *v, Vehicle *nomove, bool reverse)
 					const Track track = TrackdirToTrack(rev_trackdir);
 
 					if (HasSignalOnTrack(gp.old_tile, track)) {
-						SignalSpeedKey speed_key = {
-							speed_key.signal_tile = gp.old_tile,
-							speed_key.signal_track = track,
-							speed_key.last_passing_train_dir = v->GetVehicleTrackdir()
-						};
-						SignalSpeedValue speed_value = {
-							speed_value.train_speed = v->First()->cur_speed,
-							speed_value.time_stamp = GetSpeedRestrictionTimeout(v->First())
-						};
-						_signal_speeds[speed_key] = speed_value;
+						if (_settings_game.vehicle.train_speed_adaption) {
+							SignalSpeedKey speed_key = {
+								speed_key.signal_tile = gp.old_tile,
+								speed_key.signal_track = track,
+								speed_key.last_passing_train_dir = v->GetVehicleTrackdir()
+							};
+							SignalSpeedValue speed_value = {
+								speed_value.train_speed = v->First()->cur_speed,
+								speed_value.time_stamp = GetSpeedRestrictionTimeout(v->First())
+							};
+							_signal_speeds[speed_key] = speed_value;
+						}
 
 						if (IsRestrictedSignal(gp.old_tile)) {
 							const TraceRestrictProgram *prog = GetExistingTraceRestrictProgram(gp.old_tile, track);

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -952,6 +952,80 @@ static void AdvanceLookAheadPosition(Train *v)
 }
 
 /**
+ * Calculates the maximum speed based on any train in front of this train.
+ */
+int Train::GetAtcMaxSpeed(int current_max_speed) const
+{
+	if (!(this->vehstatus & VS_CRASHED) && _settings_game.vehicle.train_speed_adaption) {
+		int atc_speed = current_max_speed;
+
+		CFollowTrackRail ft(this);
+		Trackdir old_td = this->GetVehicleTrackdir();
+
+		if (ft.Follow(this->tile, this->GetVehicleTrackdir())) {
+			/* Basic idea: Follow the track for 20 tiles or 3 signals (i.e. at most two signal blocks) looking for other trains. */
+			/* If we find one (that meets certain restrictions), we limit the max speed to the speed of that train. */
+			int num_tiles = 0;
+			int num_signals = 0;
+
+			do {
+				old_td = ft.m_old_td;
+
+				/* If we are on a depot or rail station tile stop searching */
+				if (IsDepotTile(ft.m_new_tile) || IsRailStationTile(ft.m_new_tile))
+					break;
+
+				/* Increment signal counter if we're on a signal */
+				if (IsTileType(ft.m_new_tile, MP_RAILWAY) && ///< Tile has rails
+					KillFirstBit(ft.m_new_td_bits) == TRACKDIR_BIT_NONE && ///< Tile has exactly *one* track
+					HasSignalOnTrack(ft.m_new_tile, TrackBitsToTrack(TrackdirBitsToTrackBits(ft.m_new_td_bits)))) { ///< Tile has signal
+					num_signals++;
+				}
+
+				/* Check if tile has train/is reserved */
+				if (KillFirstBit(ft.m_new_td_bits) == TRACKDIR_BIT_NONE && ///< Tile has exactly *one* track
+					HasReservedTracks(ft.m_new_tile, TrackdirBitsToTrackBits(ft.m_new_td_bits))) { ///< Tile is reserved
+					Train* other_train = GetTrainForReservation(ft.m_new_tile, TrackBitsToTrack(TrackdirBitsToTrackBits(ft.m_new_td_bits)));
+
+
+					if (other_train != nullptr &&
+						other_train != this && ///< Other train is not this train
+						other_train->GetAccelerationStatus() != AS_BRAKE) { ///< Other train is not braking
+						atc_speed = other_train->GetCurrentSpeed();
+						break;
+					}
+				}
+
+				/* Decide what in direction to continue: reservation, straight or "first/only" direction. */
+				/* Abort if there's no reservation even though the tile contains multiple tracks. */
+				const TrackdirBits reserved = ft.m_new_td_bits & TrackBitsToTrackdirBits(GetReservedTrackbits(ft.m_new_tile));
+
+				if (reserved != TRACKDIR_BIT_NONE) {
+					// There is a reservation to follow.
+					old_td = FindFirstTrackdir(reserved);
+				}
+				else if (KillFirstBit(ft.m_new_td_bits) != TRACKDIR_BIT_NONE) {
+					// Tile has more than one track and we have no reservation. Bail out.
+					break;
+				}
+				else {
+					// There was no reservation but there is only one direction to follow, so follow it.
+					old_td = FindFirstTrackdir(ft.m_new_td_bits);
+				}
+
+				num_tiles++;
+			} while (num_tiles < 20 && num_signals < 3 && ft.Follow(ft.m_new_tile, old_td));
+		}
+
+		/* Check that the ATC speed is sufficiently large.
+		   Avoids assertion error in UpdateSpeed(). */
+		current_max_speed = std::max(25, std::min(current_max_speed, atc_speed));
+	}
+
+	return current_max_speed;
+}
+
+/**
  * Calculates the maximum speed information of the vehicle under its current conditions.
  * @return Maximum speed information of the vehicle.
  */
@@ -960,6 +1034,8 @@ Train::MaxSpeedInfo Train::GetCurrentMaxSpeedInfoInternal(bool update_state) con
 	int max_speed = _settings_game.vehicle.train_acceleration_model == AM_ORIGINAL ?
 			this->gcache.cached_max_track_speed :
 			std::min<int>(this->tcache.cached_max_curve_speed, this->gcache.cached_max_track_speed);
+
+	max_speed = GetAtcMaxSpeed(max_speed);
 
 	if (this->current_order.IsType(OT_LOADING_ADVANCE)) max_speed = std::min(max_speed, 15);
 

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -1047,7 +1047,7 @@ Train::MaxSpeedInfo Train::GetCurrentMaxSpeedInfoInternal(bool update_state) con
 			this->gcache.cached_max_track_speed :
 			std::min<int>(this->tcache.cached_max_curve_speed, this->gcache.cached_max_track_speed);
 
-	if (_settings_game.vehicle.train_speed_adaption) max_speed = std::min<int>(max_speed, GetAtcMaxSpeed());
+	if (_settings_game.vehicle.train_speed_adaptation) max_speed = std::min<int>(max_speed, GetAtcMaxSpeed());
 
 	if (this->current_order.IsType(OT_LOADING_ADVANCE)) max_speed = std::min(max_speed, 15);
 
@@ -5592,7 +5592,7 @@ bool TrainController(Train *v, Vehicle *nomove, bool reverse)
 		if (update_signals_crossing) {
 
 			if (v->IsFrontEngine()) {
-				if (_settings_game.vehicle.train_speed_adaption && IsTileType(gp.old_tile, MP_RAILWAY) && HasSignals(gp.old_tile)) {
+				if (_settings_game.vehicle.train_speed_adaptation && IsTileType(gp.old_tile, MP_RAILWAY) && HasSignals(gp.old_tile)) {
 					const TrackdirBits rev_tracks = TrackBitsToTrackdirBits(GetTrackBits(gp.old_tile)) & DiagdirReachesTrackdirs(ReverseDiagDir(enterdir));
 					const Trackdir rev_trackdir = FindFirstTrackdir(rev_tracks);
 					const Track track = TrackdirToTrack(rev_trackdir);
@@ -5658,7 +5658,7 @@ bool TrainController(Train *v, Vehicle *nomove, bool reverse)
 					const Track track = TrackdirToTrack(rev_trackdir);
 
 					if (HasSignalOnTrack(gp.old_tile, track)) {
-						if (_settings_game.vehicle.train_speed_adaption) {
+						if (_settings_game.vehicle.train_speed_adaptation) {
 							SignalSpeedKey speed_key = {
 								speed_key.signal_tile = gp.old_tile,
 								speed_key.signal_track = track,

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -987,7 +987,6 @@ int Train::GetAtcMaxSpeed(int current_max_speed) const
 					HasReservedTracks(ft.m_new_tile, TrackdirBitsToTrackBits(ft.m_new_td_bits))) { ///< Tile is reserved
 					Train* other_train = GetTrainForReservation(ft.m_new_tile, TrackBitsToTrack(TrackdirBitsToTrackBits(ft.m_new_td_bits)));
 
-
 					if (other_train != nullptr &&
 						other_train != this && ///< Other train is not this train
 						other_train->GetAccelerationStatus() != AS_BRAKE) { ///< Other train is not braking
@@ -1005,8 +1004,12 @@ int Train::GetAtcMaxSpeed(int current_max_speed) const
 					old_td = FindFirstTrackdir(reserved);
 				}
 				else if (KillFirstBit(ft.m_new_td_bits) != TRACKDIR_BIT_NONE) {
-					// Tile has more than one track and we have no reservation. Bail out.
-					break;
+					bool path_found = false;
+					old_td = TrackToTrackdir(YapfTrainChooseTrack(this, ft.m_new_tile, ft.m_exitdir, TrackdirBitsToTrackBits(ft.m_new_td_bits), path_found, false, nullptr));
+					if(!path_found || old_td == INVALID_TRACKDIR) {
+						// Tile has more than one track and we have no path. Bail out.
+						break;
+					}
 				}
 				else {
 					// There was no reservation but there is only one direction to follow, so follow it.

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -5562,7 +5562,7 @@ bool TrainController(Train *v, Vehicle *nomove, bool reverse)
 
 					if (found_speed_restriction != _signal_speeds.end()) {
 						if (IsOutOfDate(found_speed_restriction->second)) {
-							_signal_speeds.erase(speed_key);
+							_signal_speeds.erase(found_speed_restriction);
 							v->signal_speed_restriction = 0;
 						} else {
 							v->signal_speed_restriction = std::max<uint16>(25, found_speed_restriction->second.train_speed);

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -987,6 +987,7 @@ int Train::GetAtcMaxSpeed(int current_max_speed) const
 					HasReservedTracks(ft.m_new_tile, TrackdirBitsToTrackBits(ft.m_new_td_bits))) { ///< Tile is reserved
 					Train* other_train = GetTrainForReservation(ft.m_new_tile, TrackBitsToTrack(TrackdirBitsToTrackBits(ft.m_new_td_bits)));
 
+
 					if (other_train != nullptr &&
 						other_train != this && ///< Other train is not this train
 						other_train->GetAccelerationStatus() != AS_BRAKE) { ///< Other train is not braking
@@ -1004,12 +1005,8 @@ int Train::GetAtcMaxSpeed(int current_max_speed) const
 					old_td = FindFirstTrackdir(reserved);
 				}
 				else if (KillFirstBit(ft.m_new_td_bits) != TRACKDIR_BIT_NONE) {
-					bool path_found = false;
-					old_td = TrackToTrackdir(YapfTrainChooseTrack(this, ft.m_new_tile, ft.m_exitdir, TrackdirBitsToTrackBits(ft.m_new_td_bits), path_found, false, nullptr));
-					if(!path_found || old_td == INVALID_TRACKDIR) {
-						// Tile has more than one track and we have no path. Bail out.
-						break;
-					}
+					// Tile has more than one track and we have no reservation. Bail out.
+					break;
 				}
 				else {
 					// There was no reservation but there is only one direction to follow, so follow it.

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -138,7 +138,7 @@ static DateTicksScaled GetSpeedRestrictionTimeout(const Train *t)
 	const int64 ticks_per_tile = 2232 / velocity;
 
 	const int64 ticks = ticks_per_tile * look_ahead_distance;
-	
+
 	return _scaled_date_ticks + ticks;
 }
 
@@ -5592,7 +5592,7 @@ bool TrainController(Train *v, Vehicle *nomove, bool reverse)
 		if (update_signals_crossing) {
 
 			if (v->IsFrontEngine()) {
-				if (IsTileType(gp.old_tile, MP_RAILWAY) && HasSignals(gp.old_tile)) {				
+				if (IsTileType(gp.old_tile, MP_RAILWAY) && HasSignals(gp.old_tile)) {
 					const TrackdirBits rev_tracks = TrackBitsToTrackdirBits(GetTrackBits(gp.old_tile)) & DiagdirReachesTrackdirs(ReverseDiagDir(enterdir));
 					const Trackdir rev_trackdir = FindFirstTrackdir(rev_tracks);
 					const Track track = TrackdirToTrack(rev_trackdir);
@@ -5614,7 +5614,7 @@ bool TrainController(Train *v, Vehicle *nomove, bool reverse)
 						v->signal_speed_restriction = 0;
 					}
 				}
-				
+
 				switch (TrainMovedChangeSignal(v, gp.new_tile, enterdir, true)) {
 					case CHANGED_NORMAL_TO_PBS_BLOCK:
 						/* We are entering a block with PBS signals right now, but

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -122,6 +122,13 @@ void ClearAllSignalSpeedRestrictions()
 	_signal_speeds.clear();
 }
 
+void AdjustAllSignalSpeedRestrictionTickValues(DateTicksScaled delta)
+{
+	for (auto &it : _signal_speeds) {
+		it.second.time_stamp += delta;
+	}
+}
+
 /** Removes all speed restrictions which have passed their timeout from all signals */
 void ClearOutOfDateSignalSpeedRestrictions()
 {

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -1014,7 +1014,7 @@ int Train::GetAtcMaxSpeed(int current_max_speed) const
 				}
 
 				num_tiles++;
-			} while (num_tiles < 20 && num_signals < 3 && ft.Follow(ft.m_new_tile, old_td));
+			} while (num_tiles < 20 && num_signals < 4 && ft.Follow(ft.m_new_tile, old_td));
 		}
 
 		/* Check that the ATC speed is sufficiently large.

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -44,6 +44,7 @@
 #include "scope.h"
 #include "core/checksum_func.hpp"
 #include "debug_settings.h"
+#include "train_speed_adaptation.h"
 
 #include "table/strings.h"
 #include "table/train_cmd.h"
@@ -76,39 +77,7 @@ enum ChooseTrainTrackFlags {
 };
 DECLARE_ENUM_AS_BIT_SET(ChooseTrainTrackFlags)
 
-struct SignalSpeedKey
-{
-	TileIndex signal_tile;
-	Track signal_track;
-	Trackdir last_passing_train_dir;
-
-	bool operator==(const SignalSpeedKey& other) const
-	{
-		return signal_tile == other.signal_tile &&
-			signal_track == other.signal_track &&
-			last_passing_train_dir == other.last_passing_train_dir;
-	}
-};
-
-struct SignalSpeedValue
-{
-	uint16 train_speed;
-	DateTicksScaled time_stamp;
-};
-
-struct SignalSpeedKeyHashFunc
-{
-	std::size_t operator() (const SignalSpeedKey &key) const
-	{
-		const std::size_t h1 = std::hash<TileIndex>()(key.signal_tile);
-		const std::size_t h2 = std::hash<Trackdir>()(key.last_passing_train_dir);
-		const std::size_t h3 = std::hash<Track>()(key.signal_track);
-
-		return (h1 ^ h2) ^ h3;
-	}
-};
-
-static std::unordered_map<SignalSpeedKey, SignalSpeedValue, SignalSpeedKeyHashFunc> _signal_speeds(1 << 16);
+std::unordered_map<SignalSpeedKey, SignalSpeedValue, SignalSpeedKeyHashFunc> _signal_speeds(1 << 16);
 
 static void TryLongReserveChooseTrainTrackFromReservationEnd(Train *v, bool no_reserve_vehicle_tile = false);
 static Track ChooseTrainTrack(Train *v, TileIndex tile, DiagDirection enterdir, TrackBits tracks, ChooseTrainTrackFlags flags, bool *p_got_reservation, ChooseTrainTrackLookAheadState lookahead_state = {});

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -994,18 +994,6 @@ static void AdvanceLookAheadPosition(Train *v)
 }
 
 /**
- * Calculates the maximum speed based on any train in front of this train.
- */
-int32 Train::GetAtcMaxSpeed() const
-{
-	if (!(this->vehstatus & VS_CRASHED) && this->signal_speed_restriction != 0) {
-		return std::max<int32>(25, this->signal_speed_restriction);
-	}
-
-	return INT32_MAX;
-}
-
-/**
  * Calculates the maximum speed information of the vehicle under its current conditions.
  * @return Maximum speed information of the vehicle.
  */
@@ -1014,8 +1002,6 @@ Train::MaxSpeedInfo Train::GetCurrentMaxSpeedInfoInternal(bool update_state) con
 	int max_speed = _settings_game.vehicle.train_acceleration_model == AM_ORIGINAL ?
 			this->gcache.cached_max_track_speed :
 			std::min<int>(this->tcache.cached_max_curve_speed, this->gcache.cached_max_track_speed);
-
-	if (_settings_game.vehicle.train_speed_adaptation) max_speed = std::min<int>(max_speed, GetAtcMaxSpeed());
 
 	if (this->current_order.IsType(OT_LOADING_ADVANCE)) max_speed = std::min(max_speed, 15);
 
@@ -1079,6 +1065,9 @@ Train::MaxSpeedInfo Train::GetCurrentMaxSpeedInfoInternal(bool update_state) con
 	}
 	if (this->speed_restriction != 0) {
 		advisory_max_speed = std::min<int>(advisory_max_speed, this->speed_restriction);
+	}
+	if (this->signal_speed_restriction != 0 && _settings_game.vehicle.train_speed_adaptation) {
+		advisory_max_speed = std::min<int>(advisory_max_speed, this->signal_speed_restriction);
 	}
 	if (this->reverse_distance > 1) {
 		advisory_max_speed = std::min<int>(advisory_max_speed, ReversingDistanceTargetSpeed(this));

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -994,7 +994,7 @@ int Train::GetAtcMaxSpeed() const
 		return std::max<int>(25, this->signal_speed_restriction);
 	}
 
-	return UINT32_MAX;
+	return INT32_MAX;
 }
 
 /**

--- a/src/train_speed_adaptation.h
+++ b/src/train_speed_adaptation.h
@@ -1,0 +1,53 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file train_speed_adaptation.h Train speed adaptation data structures. */
+
+#ifndef TRAIN_SPEED_ADAPTATION_H
+#define TRAIN_SPEED_ADAPTATION_H
+
+#include "date_type.h"
+#include "track_type.h"
+#include "tile_type.h"
+
+#include <unordered_map>
+
+struct SignalSpeedKey
+{
+	TileIndex signal_tile;
+	Track signal_track;
+	Trackdir last_passing_train_dir;
+
+	bool operator==(const SignalSpeedKey& other) const
+	{
+		return signal_tile == other.signal_tile &&
+			signal_track == other.signal_track &&
+			last_passing_train_dir == other.last_passing_train_dir;
+	}
+};
+
+struct SignalSpeedValue
+{
+	uint16 train_speed;
+	DateTicksScaled time_stamp;
+};
+
+struct SignalSpeedKeyHashFunc
+{
+	std::size_t operator() (const SignalSpeedKey &key) const
+	{
+		const std::size_t h1 = std::hash<TileIndex>()(key.signal_tile);
+		const std::size_t h2 = std::hash<Trackdir>()(key.last_passing_train_dir);
+		const std::size_t h3 = std::hash<Track>()(key.signal_track);
+
+		return (h1 ^ h2) ^ h3;
+	}
+};
+
+extern std::unordered_map<SignalSpeedKey, SignalSpeedValue, SignalSpeedKeyHashFunc> _signal_speeds;
+
+#endif /* TRAIN_SPEED_ADAPTATION_H */

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4310,4 +4310,7 @@ void ShiftVehicleDates(int interval)
 	for (Vehicle *v : Vehicle::Iterate()) {
 		v->date_of_last_service += interval;
 	}
+
+	extern void AdjustAllSignalSpeedRestrictionTickValues(DateTicksScaled delta);
+	AdjustAllSignalSpeedRestrictionTickValues(interval * DAY_TICKS * _settings_game.economy.day_length_factor);
 }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2417,6 +2417,7 @@ void VehicleEnterDepot(Vehicle *v)
 			ClrBit(t->flags, VRF_TOGGLE_REVERSE);
 			t->ConsistChanged(CCF_ARRANGE);
 			t->reverse_distance = 0;
+			t->signal_speed_restriction = 0;
 			t->lookahead.reset();
 			if (!(t->vehstatus & VS_CRASHED)) {
 				t->crash_anim_pos = 0;


### PR DESCRIPTION
## Motivation / Problem

Without realistic breaking trains would continuously run into the train in front of them.

## Description

This change makes them adjust their speed based on trains in front of them.

## Limitations

It breaks when approaching junctions and it does not play nice with the realistic breaking system. The latter smoothes out the effect of the orginal oscillation but it also prevents the ATC from eliminating it because it is more conservative.
A better solution needs to be found to prevent the speed oscillation of trains but this might work as an interim solution when playing without realistic breaking. Since the functionality is all compacted into one single function it can later be easily eliminated once a better solution has been found.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)