### PR TITLE
Show more details on train max speed when loaded

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4965,6 +4965,9 @@ STR_VEHICLE_DETAILS_CARGO_EMPTY                                 :{LTBLUE}Empty
 STR_VEHICLE_DETAILS_CARGO_FROM                                  :{LTBLUE}{CARGO_LONG} from {STATION}
 STR_VEHICLE_DETAILS_CARGO_FROM_MULT                             :{LTBLUE}{CARGO_LONG} from {STATION} (x{NUM})
 
+STR_VEHICLE_DETAILS_TRAIN_TOTAL_WEIGHT                          :{BLACK}Total weight: {LTBLUE}{WEIGHT_SHORT} (empty) - {LTBLUE}{WEIGHT_SHORT} (loaded)
+STR_VEHICLE_DETAILS_TRAIN_MAX_SPEED                             :{BLACK}Max. speed: {LTBLUE}{VELOCITY} (empty) - {LTBLUE}{VELOCITY} (loaded)
+
 STR_VEHICLE_DETAIL_TAB_CARGO                                    :{BLACK}Cargo
 STR_VEHICLE_DETAILS_TRAIN_CARGO_TOOLTIP                         :{BLACK}Show details of cargo carried
 STR_VEHICLE_DETAIL_TAB_INFORMATION                              :{BLACK}Information

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4965,8 +4965,8 @@ STR_VEHICLE_DETAILS_CARGO_EMPTY                                 :{LTBLUE}Empty
 STR_VEHICLE_DETAILS_CARGO_FROM                                  :{LTBLUE}{CARGO_LONG} from {STATION}
 STR_VEHICLE_DETAILS_CARGO_FROM_MULT                             :{LTBLUE}{CARGO_LONG} from {STATION} (x{NUM})
 
-STR_VEHICLE_DETAILS_TRAIN_TOTAL_WEIGHT                          :{BLACK}Total weight: {LTBLUE}{WEIGHT_SHORT} (empty) - {LTBLUE}{WEIGHT_SHORT} (loaded)
-STR_VEHICLE_DETAILS_TRAIN_MAX_SPEED                             :{BLACK}Max. speed: {LTBLUE}{VELOCITY} (empty) - {LTBLUE}{VELOCITY} (loaded)
+STR_VEHICLE_DETAILS_TRAIN_TOTAL_WEIGHT                          :{BLACK}Total weight: {LTBLUE}{WEIGHT_SHORT} {BLACK}(empty) - {LTBLUE}{WEIGHT_SHORT} {BLACK}(loaded)
+STR_VEHICLE_DETAILS_TRAIN_MAX_SPEED                             :{BLACK}Max. speed: {LTBLUE}{VELOCITY} {BLACK}(empty) - {LTBLUE}{VELOCITY} {BLACK}(loaded)
 
 STR_VEHICLE_DETAIL_TAB_CARGO                                    :{BLACK}Cargo
 STR_VEHICLE_DETAILS_TRAIN_CARGO_TOOLTIP                         :{BLACK}Show details of cargo carried

--- a/src/lang/german.txt
+++ b/src/lang/german.txt
@@ -4821,6 +4821,9 @@ STR_VEHICLE_DETAILS_CARGO_EMPTY                                 :{LTBLUE}Leer
 STR_VEHICLE_DETAILS_CARGO_FROM                                  :{LTBLUE}{CARGO_LONG} von {STATION}
 STR_VEHICLE_DETAILS_CARGO_FROM_MULT                             :{LTBLUE}{CARGO_LONG} von {STATION} (x{NUM})
 
+STR_VEHICLE_DETAILS_TRAIN_TOTAL_WEIGHT                          :{BLACK}Gesamtgewicht: {LTBLUE}{WEIGHT_SHORT} {BLACK}(leer) – {LTBLUE}{WEIGHT_SHORT} {BLACK}(beladen)
+STR_VEHICLE_DETAILS_TRAIN_MAX_SPEED                             :{BLACK}Max. Geschwindigkeit: {LTBLUE}{VELOCITY} {BLACK}(leer) - {LTBLUE}{VELOCITY} {BLACK}(beladen)
+
 STR_VEHICLE_DETAIL_TAB_CARGO                                    :{BLACK}Fracht
 STR_VEHICLE_DETAILS_TRAIN_CARGO_TOOLTIP                         :{BLACK}Zeige Einzelheiten zur geladenen Fracht
 STR_VEHICLE_DETAIL_TAB_INFORMATION                              :{BLACK}Information

--- a/src/train.h
+++ b/src/train.h
@@ -267,7 +267,7 @@ public:
 		return const_cast<Train *>(const_cast<const Train *>(this)->GetStationLoadingVehicle());
 	}
 
-	inline uint16 GetCargoWeight(uint cargo_amount) const
+	uint16 GetCargoWeight(uint cargo_amount) const
 	{
 		if (cargo_amount > 0) {
 			return (CargoSpec::Get(this->cargo_type)->weight * cargo_amount * FreightWagonMult(this->cargo_type)) / 16;
@@ -277,10 +277,10 @@ public:
 	}
 
 	/**
-	* Gets the weight of this vehicle when empty.
-	* @return Empty weight in tonnes.
-	*/
-	uint16 GetEmptyWeight() const
+	 * Allows to know the weight value that this vehicle will use (excluding cargo).
+	 * @return Weight value from the engine in tonnes.
+	 */
+	uint16 GetWeightWithoutCargo() const
 	{
 		uint16 weight = 0;
 
@@ -294,28 +294,16 @@ public:
 			weight += RailVehInfo(this->gcache.first_engine)->pow_wag_weight;
 		}
 
-		return weight * (this->IsWagon() ? FreightWagonMult(this->cargo_type) : 1);
+		return weight;
 	}
 
 	/**
-	* Gets the weight of this vehicle when fully loaded.
-	* @return Loaded weight in tonnes.
-	*/
-	uint16 GetLoadedWeight() const
+	 * Allows to know the weight value that this vehicle will use (cargo only).
+	 * @return Weight value from the engine in tonnes.
+	 */
+	uint16 GetCargoWeight() const
 	{
-		uint16 weight = (CargoSpec::Get(this->cargo_type)->weight * this->cargo_cap) / 16;
-
-		/* Vehicle weight is not added for articulated parts. */
-		if (!this->IsArticulatedPart()) {
-			weight += GetVehicleProperty(this, PROP_TRAIN_WEIGHT, RailVehInfo(this->engine_type)->weight);
-		}
-
-		/* Powered wagons have extra weight added. */
-		if (HasBit(this->flags, VRF_POWEREDWAGON)) {
-			weight += RailVehInfo(this->gcache.first_engine)->pow_wag_weight;
-		}
-
-		return weight * (this->IsWagon() ? FreightWagonMult(this->cargo_type) : 1);
+		return this->GetCargoWeight(this->cargo.StoredCount());
 	}
 
 protected: // These functions should not be called outside acceleration code.
@@ -367,36 +355,6 @@ protected: // These functions should not be called outside acceleration code.
 		}
 
 		return 0;
-	}
-
-	/**
-	 * Allows to know the weight value that this vehicle will use (excluding cargo).
-	 * @return Weight value from the engine in tonnes.
-	 */
-	inline uint16 GetWeightWithoutCargo() const
-	{
-		uint16 weight = 0;
-
-		/* Vehicle weight is not added for articulated parts. */
-		if (!this->IsArticulatedPart()) {
-			weight += GetVehicleProperty(this, PROP_TRAIN_WEIGHT, RailVehInfo(this->engine_type)->weight);
-		}
-
-		/* Powered wagons have extra weight added. */
-		if (HasBit(this->flags, VRF_POWEREDWAGON)) {
-			weight += RailVehInfo(this->gcache.first_engine)->pow_wag_weight;
-		}
-
-		return weight;
-	}
-
-	/**
-	 * Allows to know the weight value that this vehicle will use (cargo only).
-	 * @return Weight value from the engine in tonnes.
-	 */
-	inline uint16 GetCargoWeight() const
-	{
-		return this->GetCargoWeight(this->cargo.StoredCount());
 	}
 
 	/**

--- a/src/train.h
+++ b/src/train.h
@@ -276,6 +276,48 @@ public:
 		}
 	}
 
+	/**
+	* Gets the weight of this vehicle when empty.
+	* @return Empty weight in tonnes.
+	*/
+	uint16 GetEmptyWeight() const
+	{
+		uint16 weight = 0;
+
+		/* Vehicle weight is not added for articulated parts. */
+		if (!this->IsArticulatedPart()) {
+			weight += GetVehicleProperty(this, PROP_TRAIN_WEIGHT, RailVehInfo(this->engine_type)->weight);
+		}
+
+		/* Powered wagons have extra weight added. */
+		if (HasBit(this->flags, VRF_POWEREDWAGON)) {
+			weight += RailVehInfo(this->gcache.first_engine)->pow_wag_weight;
+		}
+
+		return weight * (this->IsWagon() ? FreightWagonMult(this->cargo_type) : 1);
+	}
+
+	/**
+	* Gets the weight of this vehicle when fully loaded.
+	* @return Loaded weight in tonnes.
+	*/
+	uint16 GetLoadedWeight() const
+	{
+		uint16 weight = (CargoSpec::Get(this->cargo_type)->weight * this->cargo_cap) / 16;
+
+		/* Vehicle weight is not added for articulated parts. */
+		if (!this->IsArticulatedPart()) {
+			weight += GetVehicleProperty(this, PROP_TRAIN_WEIGHT, RailVehInfo(this->engine_type)->weight);
+		}
+
+		/* Powered wagons have extra weight added. */
+		if (HasBit(this->flags, VRF_POWEREDWAGON)) {
+			weight += RailVehInfo(this->gcache.first_engine)->pow_wag_weight;
+		}
+
+		return weight * (this->IsWagon() ? FreightWagonMult(this->cargo_type) : 1);
+	}
+
 protected: // These functions should not be called outside acceleration code.
 	/**
 	 * Gets the speed a broken down train (low speed breakdown) is limited to.

--- a/src/train_gui.cpp
+++ b/src/train_gui.cpp
@@ -518,18 +518,20 @@ void DrawTrainDetails(const Train *v, int left, int right, int y, int vscroll_po
 		int loaded_max_speed = 0;
 
 		for (const Vehicle *u = v; u != nullptr; u = u->Next()) {
+			const Train *train = Train::From(u);
+			const auto weight_without_cargo = train->GetWeightWithoutCargo();
 			act_cargo[u->cargo_type] += u->cargo.StoredCount();
 			max_cargo[u->cargo_type] += u->cargo_cap;
 			feeder_share             += u->cargo.FeederShare();
-			empty_weight             += Train::From(u)->GetEmptyWeight();
-			loaded_weight            += Train::From(u)->GetLoadedWeight();
+			empty_weight             += weight_without_cargo;
+			loaded_weight            += weight_without_cargo + train->GetCargoWeight(train->cargo_cap);
 		}
 
 		const auto rolling_friction = 15 * (512 + v->GetDisplayMaxSpeed()) / 512;
 		const auto tractive_effort_empty = empty_weight * rolling_friction;
 		const auto tractive_effort_loaded = loaded_weight * rolling_friction;
-		const int power = v->gcache.cached_power * 746;
-		const int max_te = v->gcache.cached_max_te;
+		const int power = static_cast<int>(v->gcache.cached_power * 746);
+		const int max_te = static_cast<int>(v->gcache.cached_max_te);
 		empty_max_speed = std::min(v->GetDisplayMaxSpeed(), (tractive_effort_empty == 0 || tractive_effort_empty > max_te) ? 0 : static_cast<int>((3.6 * power) / tractive_effort_empty));
 		loaded_max_speed = std::min(v->GetDisplayMaxSpeed(), (tractive_effort_loaded == 0 || tractive_effort_loaded > max_te) ? 0 : static_cast<int>((3.6 * power) / tractive_effort_loaded));
 

--- a/src/train_gui.cpp
+++ b/src/train_gui.cpp
@@ -390,7 +390,12 @@ int GetTrainDetailsWndVScroll(VehicleID veh_id, TrainDetailsWindowTabs det_tab)
 		for (CargoID i = 0; i < NUM_CARGO; i++) {
 			if (max_cargo[i] > 0) num++; // only count carriages that the train has
 		}
-		num += 5; // needs five more because first line is description string and we have the weight and speed info
+
+		if (_settings_game.vehicle.train_acceleration_model != AM_ORIGINAL) {
+			num += 5; // needs five more because first line is description string and we have the weight and speed info and the feeder share
+		} else {
+			num += 2; // needs one more because first line is description string and we have the feeder share
+		}
 	} else {
 		for (const Train *v = Train::Get(veh_id); v != nullptr; v = v->GetNextVehicle()) {
 			GetCargoSummaryOfArticulatedVehicle(v, &_cargo_summary);
@@ -584,25 +589,27 @@ void DrawTrainDetails(const Train *v, int left, int right, int y, int vscroll_po
 			loaded_weight            += weight_without_cargo + train->GetCargoWeight(train->cargo_cap);
 		}
 
-		const int empty_max_speed = GetMaxSpeed(v, empty_weight, v->GetDisplayMaxSpeed());
-		const int loaded_max_speed = GetMaxSpeed(v, loaded_weight, v->GetDisplayMaxSpeed());
+		if (_settings_game.vehicle.train_acceleration_model != AM_ORIGINAL) {
+			const int empty_max_speed = GetMaxSpeed(v, empty_weight, v->GetDisplayMaxSpeed());
+			const int loaded_max_speed = GetMaxSpeed(v, loaded_weight, v->GetDisplayMaxSpeed());
 
-		if (--vscroll_pos < 0 && vscroll_pos >= -vscroll_cap) {
-			SetDParam(0, empty_weight);
-			SetDParam(1, loaded_weight);
-			DrawString(left, right, y + text_y_offset, STR_VEHICLE_DETAILS_TRAIN_TOTAL_WEIGHT);
-			y += line_height;
-		}
+			if (--vscroll_pos < 0 && vscroll_pos >= -vscroll_cap) {
+				SetDParam(0, empty_weight);
+				SetDParam(1, loaded_weight);
+				DrawString(left, right, y + text_y_offset, STR_VEHICLE_DETAILS_TRAIN_TOTAL_WEIGHT);
+				y += line_height;
+			}
 
-		if (--vscroll_pos < 0 && vscroll_pos >= -vscroll_cap) {
-			SetDParam(0, empty_max_speed);
-			SetDParam(1, loaded_max_speed);
-			DrawString(left, right, y + text_y_offset, STR_VEHICLE_DETAILS_TRAIN_MAX_SPEED);
-			y += line_height;
-		}
+			if (--vscroll_pos < 0 && vscroll_pos >= -vscroll_cap) {
+				SetDParam(0, empty_max_speed);
+				SetDParam(1, loaded_max_speed);
+				DrawString(left, right, y + text_y_offset, STR_VEHICLE_DETAILS_TRAIN_MAX_SPEED);
+				y += line_height;
+			}
 
-		if (--vscroll_pos < 0 && vscroll_pos >= -vscroll_cap) {
-			y += line_height;
+			if (--vscroll_pos < 0 && vscroll_pos >= -vscroll_cap) {
+				y += line_height;
+			}
 		}
 
 		if (--vscroll_pos < 0 && vscroll_pos >= -vscroll_cap) {

--- a/src/train_gui.cpp
+++ b/src/train_gui.cpp
@@ -390,7 +390,7 @@ int GetTrainDetailsWndVScroll(VehicleID veh_id, TrainDetailsWindowTabs det_tab)
 		for (CargoID i = 0; i < NUM_CARGO; i++) {
 			if (max_cargo[i] > 0) num++; // only count carriages that the train has
 		}
-		num++; // needs one more because first line is description string
+		num += 5; // needs five more because first line is description string and we have the weight and speed info
 	} else {
 		for (const Train *v = Train::Get(veh_id); v != nullptr; v = v->GetNextVehicle()) {
 			GetCargoSummaryOfArticulatedVehicle(v, &_cargo_summary);
@@ -512,19 +512,52 @@ void DrawTrainDetails(const Train *v, int left, int right, int y, int vscroll_po
 		CargoArray act_cargo;
 		CargoArray max_cargo;
 		Money feeder_share = 0;
+		uint16 empty_weight = 0;
+		uint16 loaded_weight = 0;
+		uint16 empty_max_speed = 0;
+		uint16 loaded_max_speed = 0;
 
 		for (const Vehicle *u = v; u != nullptr; u = u->Next()) {
 			act_cargo[u->cargo_type] += u->cargo.StoredCount();
 			max_cargo[u->cargo_type] += u->cargo_cap;
 			feeder_share             += u->cargo.FeederShare();
+			empty_weight             += Train::From(u)->GetEmptyWeight();
+			loaded_weight            += Train::From(u)->GetLoadedWeight();
 		}
 
-		/* draw total cargo tab */
-		DrawString(left, right, y + text_y_offset, STR_VEHICLE_DETAILS_TRAIN_TOTAL_CAPACITY_TEXT);
-		y += line_height;
+		const auto rolling_friction = 15 * (512 + v->GetDisplayMaxSpeed()) / 512;
+		const auto tractive_effort_empty = empty_weight * rolling_friction;
+		const auto tractive_effort_loaded = loaded_weight * rolling_friction;
+		const auto power = v->gcache.cached_power * 746ll;
+		const auto max_te = v->gcache.cached_max_te;
+		empty_max_speed = std::min<uint16>(v->GetDisplayMaxSpeed(), (tractive_effort_empty == 0 || tractive_effort_empty > max_te) ? 0 : (3.6 * (power / tractive_effort_empty)));
+		loaded_max_speed = std::min<uint16>(v->GetDisplayMaxSpeed(), (tractive_effort_loaded == 0 || tractive_effort_loaded > max_te) ? 0 : (3.6 * (power / tractive_effort_loaded)));
+
+		if (--vscroll_pos < 0 && vscroll_pos >= -vscroll_cap) {
+			SetDParam(0, empty_weight);
+			SetDParam(1, loaded_weight);
+			DrawString(left, right, y + text_y_offset, STR_VEHICLE_DETAILS_TRAIN_TOTAL_WEIGHT);
+			y += line_height;
+		}
+
+		if (--vscroll_pos < 0 && vscroll_pos >= -vscroll_cap) {
+			SetDParam(0, empty_max_speed);
+			SetDParam(1, loaded_max_speed);
+			DrawString(left, right, y + text_y_offset, STR_VEHICLE_DETAILS_TRAIN_MAX_SPEED);
+			y += line_height;
+		}
+
+		if (--vscroll_pos < 0 && vscroll_pos >= -vscroll_cap) {
+			y += line_height;
+		}
+
+		if (--vscroll_pos < 0 && vscroll_pos >= -vscroll_cap) {
+			DrawString(left, right, y + text_y_offset, STR_VEHICLE_DETAILS_TRAIN_TOTAL_CAPACITY_TEXT);
+			y += line_height;
+		}
 
 		for (CargoID i = 0; i < NUM_CARGO; i++) {
-			if (max_cargo[i] > 0 && --vscroll_pos < 0 && vscroll_pos > -vscroll_cap) {
+			if (max_cargo[i] > 0 && --vscroll_pos < 0 && vscroll_pos >= -vscroll_cap) {
 				SetDParam(0, i);            // {CARGO} #1
 				SetDParam(1, act_cargo[i]); // {CARGO} #2
 				SetDParam(2, i);            // {SHORTCARGO} #1
@@ -534,7 +567,16 @@ void DrawTrainDetails(const Train *v, int left, int right, int y, int vscroll_po
 				y += line_height;
 			}
 		}
-		SetDParam(0, feeder_share);
-		DrawString(left, right, y + text_y_offset, STR_VEHICLE_INFO_FEEDER_CARGO_VALUE);
+
+		for (const Vehicle *u = v; u != nullptr; u = u->Next()) {
+			act_cargo[u->cargo_type] += u->cargo.StoredCount();
+			max_cargo[u->cargo_type] += u->cargo_cap;
+			feeder_share             += u->cargo.FeederShare();
+		}
+
+		if (--vscroll_pos < 0 && vscroll_pos >= -vscroll_cap) {
+			SetDParam(0, feeder_share);
+			DrawString(left, right, y + text_y_offset, STR_VEHICLE_INFO_FEEDER_CARGO_VALUE);
+		}
 	}
 }

--- a/src/train_gui.cpp
+++ b/src/train_gui.cpp
@@ -512,10 +512,10 @@ void DrawTrainDetails(const Train *v, int left, int right, int y, int vscroll_po
 		CargoArray act_cargo;
 		CargoArray max_cargo;
 		Money feeder_share = 0;
-		uint16 empty_weight = 0;
-		uint16 loaded_weight = 0;
-		uint16 empty_max_speed = 0;
-		uint16 loaded_max_speed = 0;
+		int empty_weight = 0;
+		int loaded_weight = 0;
+		int empty_max_speed = 0;
+		int loaded_max_speed = 0;
 
 		for (const Vehicle *u = v; u != nullptr; u = u->Next()) {
 			act_cargo[u->cargo_type] += u->cargo.StoredCount();
@@ -528,10 +528,10 @@ void DrawTrainDetails(const Train *v, int left, int right, int y, int vscroll_po
 		const auto rolling_friction = 15 * (512 + v->GetDisplayMaxSpeed()) / 512;
 		const auto tractive_effort_empty = empty_weight * rolling_friction;
 		const auto tractive_effort_loaded = loaded_weight * rolling_friction;
-		const auto power = v->gcache.cached_power * 746ll;
-		const auto max_te = v->gcache.cached_max_te;
-		empty_max_speed = std::min<uint16>(v->GetDisplayMaxSpeed(), (tractive_effort_empty == 0 || tractive_effort_empty > max_te) ? 0 : (3.6 * (power / tractive_effort_empty)));
-		loaded_max_speed = std::min<uint16>(v->GetDisplayMaxSpeed(), (tractive_effort_loaded == 0 || tractive_effort_loaded > max_te) ? 0 : (3.6 * (power / tractive_effort_loaded)));
+		const int power = v->gcache.cached_power * 746;
+		const int max_te = v->gcache.cached_max_te;
+		empty_max_speed = std::min(v->GetDisplayMaxSpeed(), (tractive_effort_empty == 0 || tractive_effort_empty > max_te) ? 0 : static_cast<int>((3.6 * power) / tractive_effort_empty));
+		loaded_max_speed = std::min(v->GetDisplayMaxSpeed(), (tractive_effort_loaded == 0 || tractive_effort_loaded > max_te) ? 0 : static_cast<int>((3.6 * power) / tractive_effort_loaded));
 
 		if (--vscroll_pos < 0 && vscroll_pos >= -vscroll_cap) {
 			SetDParam(0, empty_weight);


### PR DESCRIPTION
## Motivation / Problem

When buying a train it is very hard to judge how much a new engine can pull. This can get difficult for new players,
especially when using realistic physics and higher cargo multipliers.

## Description

This change displays the weight and max speed both in empty and loaded state. While buying wagons for the train the view updates and the player can check what the current max speed on flat terrain is, when all wagons are fully loaded.

![image](https://user-images.githubusercontent.com/61427715/122669479-dc4d2700-d1bd-11eb-9bce-a81b743ea5fc.png)

## Limitations

The max speed when loaded is calculated with a fixed rolling friction value based on the maximum speed. This makes sure that if the screen shows that the maximum speed can be reached, this will indeed be possible (this is probably of most interest). However at lower speeds the coefficient is somewhat off so the train might actually be able to go faster since the friction is lower. But I think it's better to be on the conservative side and make sure whatever the GUI shows as loaded speed can actually be achieved.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
