### PR TITLE
Fix some type conversion warnings

### DIFF
--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -254,8 +254,8 @@ void ClientNetworkContentSocketHandler::RequestContentList(ContentVector *cv, bo
 
 	while (cv->size() > offset) {
 		Packet *p = new Packet(send_md5sum ? PACKET_CONTENT_CLIENT_INFO_EXTID_MD5 : PACKET_CONTENT_CLIENT_INFO_EXTID, TCP_MTU);
-		const uint to_send = (uint)std::min<uint>(cv->size() - offset, max_per_packet);
-		p->Send_uint8(to_send);
+		const uint to_send = std::min<uint>(static_cast<uint>(cv->size() - offset), max_per_packet);
+		p->Send_uint8(static_cast<uint8>(to_send));
 
 		for (uint i = 0; i < to_send; i++) {
 			const ContentInfo *ci = (*cv)[offset + i];

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -474,7 +474,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendDesyncLog(const std::strin
 	for (size_t offset = 0; offset < log.size();) {
 		Packet *p = new Packet(PACKET_SERVER_DESYNC_LOG, SHRT_MAX);
 		size_t size = std::min<size_t>(log.size() - offset, SHRT_MAX - 2 - p->Size());
-		p->Send_uint16(size);
+		p->Send_uint16(static_cast<uint16>(size));
 		p->Send_binary(log.data() + offset, size);
 		this->SendPacket(p);
 

--- a/src/network/network_udp.cpp
+++ b/src/network/network_udp.cpp
@@ -329,7 +329,7 @@ void ServerNetworkUDPSocketHandler::Receive_CLIENT_GET_NEWGRFS(Packet *p, Networ
 		if (in_reply.empty()) return;
 
 		Packet packet(PACKET_UDP_SERVER_NEWGRFS);
-		packet.Send_uint8(in_reply.size());
+		packet.Send_uint8(static_cast<uint8>(in_reply.size()));
 		for (const GRFInfo &info : in_reply) {
 			char name[NETWORK_GRF_NAME_LENGTH];
 

--- a/src/saveload/cargopacket_sl.cpp
+++ b/src/saveload/cargopacket_sl.cpp
@@ -171,8 +171,8 @@ void Save_CPDP()
  */
 void Load_CPDP()
 {
-	uint count = SlGetFieldLength() / 16;
-	uint last_cargo_packet_id = (uint) -1;
+	uint count = static_cast<uint>(SlGetFieldLength() / 16);
+	uint last_cargo_packet_id = std::numeric_limits<uint32_t>::max();
 
 	for (uint i = 0; i < count; i++) {
 		uint64 k = SlReadUint64();

--- a/src/saveload/extended_ver_sl.cpp
+++ b/src/saveload/extended_ver_sl.cpp
@@ -644,9 +644,9 @@ static void loadVL(const SlxiSubChunkInfo *info, uint32 length)
 
 static uint32 saveVL(const SlxiSubChunkInfo *info, bool dry_run)
 {
-	size_t length = strlen(_openttd_revision);
+	const size_t length = strlen(_openttd_revision);
 	if (!dry_run) MemoryDumper::GetCurrent()->CopyBytes(reinterpret_cast<const byte *>(_openttd_revision), length);
-	return length;
+	return static_cast<uint32>(length);
 }
 
 static void loadLC(const SlxiSubChunkInfo *info, uint32 length)

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -800,9 +800,9 @@ void SlSetLength(size_t length)
 						SlWriteByte(CH_EXT_HDR);
 						SlWriteUint32(static_cast<uint32>(SLCEHF_BIG_RIFF));
 					}
-					SlWriteUint32((uint32)((length & 0xFFFFFF) | ((length >> 24) << 28)));
+					SlWriteUint32(static_cast<uint32>((length & 0xFFFFFF) | ((length >> 24) << 28)));
 					if (length >= (1 << 28)) {
-						SlWriteUint32(length >> 28);
+						SlWriteUint32(static_cast<uint32>(length >> 28));
 					}
 					break;
 				case CH_ARRAY:

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -1809,7 +1809,7 @@ static void DrawBridgeSignalOnMiddlePart(const TileInfo *ti, TileIndex bridge_st
 				sprite += SPR_ORIGINAL_SIGNALS_BASE + (position << 1);
 			} else {
 				/* All other signals are picked from add on sprites. */
-				sprite += SPR_SIGNALS_BASE + ((int)SIGTYPE_NORMAL - 1) * 16 + variant * 64 + (position << 1);
+				sprite += SPR_SIGNALS_BASE + (variant * 64) + (position << 1) - 16;
 			}
 
 			AddSortableSpriteToDraw(sprite, PAL_NONE, x, y, 1, 1, TILE_HEIGHT, z, false, 0, 0, BB_Z_SEPARATOR);


### PR DESCRIPTION
## Motivation / Problem

Fixing a few type conversion warnings

## Description

Crap like "(uint) -1" is why I hate working with C++ code bases... who writes crap like that??
It's a joke that such a thing is even a legal expression.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
