### PR TITLE
Minor additions

### DIFF
--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -1032,6 +1032,7 @@ public:
 
 			case WID_GL_SORT_BY_DROPDOWN:
 				this->vehgroups.SetSortType(index);
+				this->UpdateSortingInterval();
 				break;
 			case WID_GL_FILTER_BY_CARGO: // Select a cargo filter criteria
 				this->SetCargoFilterIndex(index);

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -722,6 +722,7 @@ public:
 		switch (widget) {
 			case WID_GL_SORT_BY_ORDER: // Flip sorting method ascending/descending
 				this->vehgroups.ToggleSortOrder();
+				this->vehgroups.ForceResort();
 				this->SetDirty();
 				break;
 

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1340,6 +1340,7 @@ public:
 					}
 				}
 				size->width = std::max(size->width, d.width + padding.width);
+				size->width = std::min<uint>(size->width, ScaleGUITrad(400));
 				break;
 			}
 

--- a/src/sortlist_type.h
+++ b/src/sortlist_type.h
@@ -55,6 +55,7 @@ protected:
 	uint8 sort_type;                          ///< what criteria to sort on
 	uint8 filter_type;                        ///< what criteria to filter on
 	uint16 resort_timer;                      ///< resort list after a given amount of ticks if set
+	uint16 resort_interval;                   ///< value to re-initialise resort_timer with after sorting
 
 	/**
 	 * Check if the list is sortable
@@ -71,8 +72,7 @@ protected:
 	 */
 	void ResetResortTimer()
 	{
-		/* Resort every 10 days */
-		this->resort_timer = DAY_TICKS * 10;
+		this->resort_timer = this->resort_interval;
 	}
 
 public:
@@ -82,7 +82,8 @@ public:
 		flags(VL_NONE),
 		sort_type(0),
 		filter_type(0),
-		resort_timer(1)
+		resort_timer(1),
+		resort_interval(DAY_TICKS * 10) /* Resort every 10 days by default */
 	{};
 
 	/**
@@ -213,6 +214,12 @@ public:
 	void ForceResort()
 	{
 		SETBITS(this->flags, VL_RESORT);
+	}
+
+	void SetResortInterval(uint16 resort_interval)
+	{
+		this->resort_interval = std::max<uint16>(1, resort_interval);
+		this->resort_timer = std::min<uint16>(this->resort_timer, this->resort_interval);
 	}
 
 	/**

--- a/src/tracerestrict_gui.cpp
+++ b/src/tracerestrict_gui.cpp
@@ -3680,6 +3680,7 @@ public:
 		switch (widget) {
 			case WID_TRSL_SORT_BY_DROPDOWN:
 				this->vehgroups.SetSortType(index);
+				this->UpdateSortingInterval();
 				break;
 
 			case WID_TRSL_FILTER_BY_CARGO: // Select a cargo filter criteria

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2232,6 +2232,7 @@ public:
 		switch (widget) {
 			case WID_VL_SORT_ORDER: // Flip sorting method ascending/descending
 				this->vehgroups.ToggleSortOrder();
+				this->vehgroups.ForceResort();
 				this->SetDirty();
 				break;
 

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -1995,6 +1995,13 @@ void BaseVehicleListWindow::DrawVehicleListItems(VehicleID selected_vehicle, int
 	}
 }
 
+void BaseVehicleListWindow::UpdateSortingInterval()
+{
+	uint16 resort_interval = DAY_TICKS * 10;
+	if (this->grouping == GB_NONE && this->vehgroups.SortType() == VST_TIMETABLE_DELAY) resort_interval = DAY_TICKS;
+	this->vehgroups.SetResortInterval(resort_interval);
+}
+
 void BaseVehicleListWindow::UpdateSortingFromGrouping()
 {
 	/* Set up sorting. Make the window-specific _sorting variable
@@ -2011,6 +2018,7 @@ void BaseVehicleListWindow::UpdateSortingFromGrouping()
 	this->vehgroups.SetListing(*this->sorting);
 	this->vehgroups.ForceRebuild();
 	this->vehgroups.NeedResort();
+	this->UpdateSortingInterval();
 }
 
 void BaseVehicleListWindow::UpdateVehicleGroupBy(GroupBy group_by)
@@ -2314,6 +2322,7 @@ public:
 
 			case WID_VL_SORT_BY_PULLDOWN:
 				this->vehgroups.SetSortType(index);
+				this->UpdateSortingInterval();
 				break;
 
 			case WID_VL_FILTER_BY_CARGO:

--- a/src/vehicle_gui_base.h
+++ b/src/vehicle_gui_base.h
@@ -133,6 +133,7 @@ public:
 
 	void OnInit() override;
 
+	void UpdateSortingInterval();
 	void UpdateSortingFromGrouping();
 
 	void DrawVehicleListItems(VehicleID selected_vehicle, int line_height, const Rect &r) const;


### PR DESCRIPTION
## Motivation / Problem

### Build Rail Station GUI

Some NewGRFs adding station tiles overdo it a bit with the category names. Also for some reason the string width returned to the game seems to be too large for some of them. This leads to unnecessarily wide reserved space and makes it awkward to select the actual tiles.

![image](https://user-images.githubusercontent.com/61427715/123039402-5bc33c00-d3f2-11eb-9906-c7cfe010c70d.png)

### Vehicle lists

The toggle sort direction button does not actually cause a resort, it just changes the ordering. This means there is no actual button to refresh the sorting. Some of the new sort categories, like timetable delay, change often. So a resort is required.

![image](https://user-images.githubusercontent.com/61427715/123058551-3aba1580-d409-11eb-8e88-99e910448ef1.png)

## Description

This sets a maximum width for the left part of the build railstation window. It also makes the toggle sort order button resort the list and adds a button to automatically do so every day. This is convenient when watching the timetable delay and other rapidly changing values.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
