### PR TITLE
Allow Rivers in Sub-Tropical climate Deserts

### DIFF
--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -1055,7 +1055,7 @@ static bool FindSpring(TileIndex tile, void *user_data)
 	if (!IsTileFlat(tile, &referenceHeight) || IsWaterTile(tile)) return false;
 
 	/* In the tropics rivers start in the rainforest. */
-	if (_settings_game.game_creation.landscape == LT_TROPIC && GetTropicZone(tile) != TROPICZONE_RAINFOREST) return false;
+	if (_settings_game.game_creation.landscape == LT_TROPIC && GetTropicZone(tile) != TROPICZONE_RAINFOREST && !_settings_game.game_creation.lakes_allowed_in_deserts) return false;
 
 	/* Are there enough higher tiles to warrant a 'spring'? */
 	uint num = 0;
@@ -1100,7 +1100,7 @@ static bool MakeLake(TileIndex tile, void *user_data)
 {
 	const MakeLakeData *data = (const MakeLakeData *)user_data;
 	if (!IsValidTile(tile) || TileHeight(tile) != data->height || !IsTileFlat(tile)) return false;
-	if (_settings_game.game_creation.landscape == LT_TROPIC && GetTropicZone(tile) == TROPICZONE_DESERT) return false;
+	if (_settings_game.game_creation.landscape == LT_TROPIC && GetTropicZone(tile) == TROPICZONE_DESERT && !_settings_game.game_creation.lakes_allowed_in_deserts) return false;
 
 	/* Offset from centre tile */
 	const int64 x_delta = (int)TileX(tile) - (int)TileX(data->centre);

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1639,8 +1639,8 @@ STR_CONFIG_SETTING_LAKE_SIZE                                    :Size of lakes: 
 STR_CONFIG_SETTING_LAKE_SIZE_HELPTEXT                           :Controls the size of lakes that are generated along rivers.
 STR_CONFIG_SETTING_LAKE_SIZE_VALUE                              :{NUM}
 STR_CONFIG_SETTING_LAKE_SIZE_ZERO                               :No lakes
-STR_CONFIG_SETTING_LAKES_ALLOWED_IN_DESERTS                     :Lakes can be generated in sub-tropic climate deserts: {STRING}
-STR_CONFIG_SETTING_LAKES_ALLOWED_IN_DESERTS_HELPTEXT            :Choose whether the lakes that spawn along rivers are allowed in deserts.
+STR_CONFIG_SETTING_LAKES_ALLOWED_IN_DESERTS                     :Lakes and rivers can be generated in sub-tropic climate deserts: {STRING}
+STR_CONFIG_SETTING_LAKES_ALLOWED_IN_DESERTS_HELPTEXT            :Choose whether lakes and rivers are allowed to spawn in sub-tropic climate deserts.
 STR_CONFIG_SETTING_RIVER_AMOUNT                                 :River amount: {STRING2}
 STR_CONFIG_SETTING_RIVER_AMOUNT_HELPTEXT                        :Choose how many rivers to generate
 STR_CONFIG_SETTING_ROCKS_AMOUNT                                 :Size of rocky patches: {STRING}


### PR DESCRIPTION
Additional tweaks to allow rivers to spawn in deserts (causing aditional tropic biome to spawn around them). This piggybacks off of the 'allow lakes in deserts' setting which to be honest never really accomplished what I wanted it to, renaming it to cover both. The actual setting name itself internally hasn't changed in case I break any of the save-game stuff JGR did for me.

In my testing so-far this is is behaving as expected, and along with previous tweaks made earlier it definitely helps rivers that start in rainforest areas actually successfully traverse towards the coast and thus take advantage of the larger rivers patch.