### PR TITLE
Setting to prevent road vehicles passing through other vehicles when blocked.

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1465,6 +1465,9 @@ STR_CONFIG_SETTING_FLIP_DIRECTION_ALL_TRAINS_HELPTEXT           :Enable flipping
 STR_CONFIG_SETTING_ROADVEH_ARTICULATED_OVERTAKING               :Articulated road vehicles may overtake: {STRING2}
 STR_CONFIG_SETTING_ROADVEH_ARTICULATED_OVERTAKING_HELPTEXT      :Enable articulated road vehicles to overtake other road vehicles.
 
+STR_CONFIG_SETTING_ROADVEH_CANT_QUANTUM_TUNNEL                  :Prevent vehicles from passing through other vehicles when blocked: {STRING2}
+STR_CONFIG_SETTING_ROADVEH_CANT_QUANTUM_TUNNEL_HELPTEXT         :Disable vehicles passing through other vehicles when their path is blocked for more than 1480 ticks.
+
 STR_CONFIG_SETTING_DRIVE_THROUGH_TRAIN_DEPOT                    :Drive-through train depots: {STRING2}
 STR_CONFIG_SETTING_DRIVE_THROUGH_TRAIN_DEPOT_HELPTEXT           :Enable emulation of drive-through train depots. Trains can move between depots placed back to back, optionally with intermediary depots in between. Requires the YAPF pathfinder.
 

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -743,7 +743,7 @@ static RoadVehicle *RoadVehFindCloseTo(RoadVehicle *v, int x, int y, Direction d
 		return nullptr;
 	}
 
-	if (update_blocked_ctr && ++front->blocked_ctr > 1480) return nullptr;
+	if (update_blocked_ctr && ++front->blocked_ctr > 1480  && (!_settings_game.vehicle.roadveh_cant_quantum_tunnel)) return nullptr;
 
 	RoadVehicle *rv = RoadVehicle::From(rvf.best);
 	if (rv != nullptr && front->IsRoadVehicleOnLevelCrossing() && (rv->First()->cur_speed == 0 || rv->First()->IsRoadVehicleStopped())) return nullptr;

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1951,6 +1951,7 @@ static SettingsContainer &GetSettingsTree()
 				physics->Add(new SettingEntry("vehicle.plane_speed"));
 				physics->Add(new SettingEntry("vehicle.ship_collision_avoidance"));
 				physics->Add(new SettingEntry("vehicle.roadveh_articulated_overtaking"));
+				physics->Add(new SettingEntry("vehicle.roadveh_cant_quantum_tunnel"));
 				physics->Add(new SettingEntry("vehicle.slow_road_vehicles_in_curves"));
 			}
 

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -614,6 +614,7 @@ struct VehicleSettings {
 	bool   no_train_crash_other_company;     ///< trains cannot crash with trains from other companies
 	bool   flip_direction_all_trains;        ///< enable flipping direction in depot for all train engine types
 	bool   roadveh_articulated_overtaking;   ///< enable articulated road vehicles overtaking other vehicles
+	bool   roadveh_cant_quantum_tunnel;      ///< enable or disable vehicles quantum tunelling through over vehicles when blocked
 	bool   drive_through_train_depot;        ///< enable drive-through train depot emulation
 };
 

--- a/src/table/settings/settings.ini
+++ b/src/table/settings/settings.ini
@@ -1799,6 +1799,14 @@ patxname = ""roadveh_articulated_overtaking.vehicle.roadveh_articulated_overtaki
 cat      = SC_BASIC
 
 [SDT_BOOL]
+var      = vehicle.roadveh_cant_quantum_tunnel
+def      = false
+str      = STR_CONFIG_SETTING_ROADVEH_CANT_QUANTUM_TUNNEL
+strhelp  = STR_CONFIG_SETTING_ROADVEH_CANT_QUANTUM_TUNNEL_HELPTEXT
+patxname = ""roadveh_cant_quantum_tunnel.vehicle.roadveh_cant_quantum_tunnel""
+cat      = SC_BASIC
+
+[SDT_BOOL]
 var      = vehicle.drive_through_train_depot
 def      = false
 str      = STR_CONFIG_SETTING_DRIVE_THROUGH_TRAIN_DEPOT


### PR DESCRIPTION
Introduces a new setting (defaulted off) to allow preventing road vehicles from performing so-called quantum tunneling through other vehicles blocking their path. Blame Azusa on discord for the name. I couldn't think of a name for the setting.

It's possible to create amazing traffic jams with this feature. This is intentional. This is officially a 'muh immersion' setting.

Next step is to tweak some road vehicle overtaking behaviors.