### PR TITLE
fix: error when removing tunnelbridge signal w/ tracerestrict

### DIFF
--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -2139,6 +2139,8 @@ CommandCost CmdRemoveSingleSignal(TileIndex tile, DoCommandFlag flags, uint32 p1
 			Track end_track = FindFirstTrack(GetAcrossTunnelBridgeTrackBits(end));
 			Company *c = Company::Get(GetTileOwner(tile));
 			c->infrastructure.signal -= GetTunnelBridgeSignalSimulationSignalCount(tile, end);
+			TraceRestrictNotifySignalRemoval(tile, track);
+			TraceRestrictNotifySignalRemoval(end, end_track);
 			ClearBridgeTunnelSignalSimulation(end, tile);
 			ClearBridgeTunnelSignalSimulation(tile, end);
 			MarkBridgeOrTunnelDirty(tile);
@@ -2146,8 +2148,6 @@ CommandCost CmdRemoveSingleSignal(TileIndex tile, DoCommandFlag flags, uint32 p1
 			AddSideToSignalBuffer(end, INVALID_DIAGDIR, GetTileOwner(tile));
 			YapfNotifyTrackLayoutChange(tile, track);
 			YapfNotifyTrackLayoutChange(end, end_track);
-			TraceRestrictNotifySignalRemoval(tile, track);
-			TraceRestrictNotifySignalRemoval(end, end_track);
 			DirtyCompanyInfrastructureWindows(GetTileOwner(tile));
 			for (Train *v : re_reserve_trains) {
 				ReReserveTrainPath(v);


### PR DESCRIPTION
## Motivation / Problem
When attempting to remove signals from a bridge or tunnel where either end of the tunnel has a tracerestrict program of any kind, the game crashes with a tile assert. This PR should fix that.


## Description
The fix re-orders the state changes to do tracerestrict notifications earlier in the removal change. The assert inside tracerestrict was tripped because it checks that there is an existing signal simulation on the bridge before proceeding. However, in the remove signal command the relevant signal bits had already been cleared, making the tiles appear as if they did not have a signal simulation. The assert then fails.


## Limitations
I don't know well enough what's going on in the signal remove command to know that this order of cleanup works entirely correctly. In testing it seemed fine, but someone more knowledgeable may have a better idea of what the intended sequence of actions should be.

