### PR TITLE
Fix: Require non-zero capacity for refit cargo type

### DIFF
--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -6999,7 +6999,7 @@ CommandCost CmdTemplateReplaceVehicle(TileIndex tile, DoCommandFlag flags, uint3
 	// if a train shall keep its old refit, store the refit setting of its first vehicle
 	if (!use_refit) {
 		for (Train *getc = incoming; getc != nullptr; getc = getc->GetNextUnit()) {
-			if (getc->cargo_type != CT_INVALID) {
+			if (getc->cargo_type != CT_INVALID && getc->cargo_cap > 0) {
 				store_refit_ct = getc->cargo_type;
 				break;
 			}


### PR DESCRIPTION
## Motivation / Problem
When using template replacement with template refit disabled, mirroring the existing train consist can result in the incorrect cargo type being selected in cases where, e.g. the locomotive has a cargo type set for livery or other reasons.


## Description
Instead of taking the first valid cargo type, this fix also checks that the vehicle has a non-zero capacity for that cargo. This results in picking a cargo that the existing train being replaced can carry some amount of and should yield successful refits more often.
