### PR TITLE
Make arctic treeline feature use the dynamic snowline if present

### DIFF
--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -69,7 +69,7 @@ static bool CanPlantTreesOnTile(TileIndex tile, bool allow_desert)
 {
 	if ((_settings_game.game_creation.tree_placer == TP_PERFECT) &&
 		(_settings_game.game_creation.landscape == LT_ARCTIC) &&
-		(GetTileZ(tile) > (_settings_game.game_creation.snow_line_height + _settings_game.construction.trees_around_snow_line_range))) {
+		(GetTileZ(tile) > (HighestSnowLine() + _settings_game.construction.trees_around_snow_line_range))) {
 		return false;
 	}
 
@@ -194,7 +194,14 @@ static TreeType GetRandomTreeType(TileIndex tile, uint seed)
 			if (range != _previous_trees_around_snow_line_range) RecalculateArcticTreeOccuranceArray();
 
 			int z = GetTileZ(tile);
-			int height_above_snow_line = z - _settings_game.game_creation.snow_line_height;
+			int height_above_snow_line = 0;
+
+			if (z > HighestSnowLine()) {
+				height_above_snow_line = z - HighestSnowLine();
+			}
+			else if (z < LowestSnowLine()) {
+				height_above_snow_line = z - LowestSnowLine();
+			}
 			uint normalised_distance = (height_above_snow_line < 0) ? -height_above_snow_line : height_above_snow_line + 1;
 			bool arctic_tree = false;
 			if (normalised_distance < _arctic_tree_occurance.size()) {
@@ -358,7 +365,7 @@ int MaxTreeCount(const TileIndex tile)
 
 	if (_settings_game.game_creation.landscape == LT_ARCTIC) {
 		if (_settings_game.construction.trees_around_snow_line_range != _previous_trees_around_snow_line_range) RecalculateArcticTreeOccuranceArray();
-		const uint height_above_snow_line = std::max<int>(0, tile_z - _settings_game.game_creation.snow_line_height);
+		const uint height_above_snow_line = std::max<int>(0, tile_z - HighestSnowLine());
 		max_trees_snow_line_based = (height_above_snow_line < _arctic_tree_occurance.size()) ?
 			(1 + (_arctic_tree_occurance[height_above_snow_line] * 4) / 255) :
 			0;
@@ -969,7 +976,7 @@ static void TileLoop_Trees(TileIndex tile)
 						if (_settings_game.game_creation.tree_placer == TP_PERFECT &&
 							((_settings_game.game_creation.landscape != LT_TROPIC && GetTileZ(tile) <= GetSparseTreeRange()) ||
 								(GetTreeType(tile) == TREE_CACTUS) ||
-								(_settings_game.game_creation.landscape == LT_ARCTIC && GetTileZ(tile) >= _settings_game.game_creation.snow_line_height + _settings_game.construction.trees_around_snow_line_range / 3))) {
+								(_settings_game.game_creation.landscape == LT_ARCTIC && GetTileZ(tile) >= HighestSnowLine() + _settings_game.construction.trees_around_snow_line_range / 3))) {
 							// On lower levels we spread more randomly to not bunch up.
 							if (GetTreeType(tile) != TREE_CACTUS || (RandomRange(100) < 50)) {
 								PlantTreeAtSameHeight(tile);


### PR DESCRIPTION
## Motivation / Problem

Currently the arctic tree range feature only considers the static snow line. With a dynamic snowline from a newGRF the trees look wrong.

**Currently:**

Winter
![Unnamed, 1st Jan 1900#27](https://user-images.githubusercontent.com/61427715/165351147-7bbb14a0-6d93-49cb-a7e8-4fb03ed8a43d.png)

Summer
![Unnamed, 22nd Jul 1900](https://user-images.githubusercontent.com/61427715/165351162-650f3b19-c63c-45e4-b585-3135f22e3470.png)

**With this change:**

Winter
![Unnamed, 1st Jan 1900#26](https://user-images.githubusercontent.com/61427715/165351221-6ff778e5-0ca9-4f53-8d7c-3c9595d4ec5c.png)

Summer
![Unnamed, 16th Jul 1900](https://user-images.githubusercontent.com/61427715/165351246-afbab9fc-e816-44e4-aa79-739d599c1052.png)

## Description

The code uses the HighestSnowLine() and LowestSnowLine() functions now, which, if no dynamic snowline is present, will fallback to the previous behavior and both return the static snowline.

## Limitations

None that I can see

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
