### PR TITLE
Fix z-check for flat road foundations

### DIFF
--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -2478,9 +2478,14 @@ static void TileLoop_Road(TileIndex tile)
 {
 	switch (_settings_game.game_creation.landscape) {
 		case LT_ARCTIC:
-			if (IsOnSnow(tile) != (GetTileZ(tile) > GetSnowLine())) {
-				ToggleSnow(tile);
-				MarkTileDirtyByTile(tile);
+			{
+				/* Flat foundation tiles should look the same as the tiles they visually connect to. */
+				int tile_z = GetFoundationSlope(tile) == SLOPE_FLAT ? GetTileMaxZ(tile) : GetTileZ(tile);
+
+				if (IsOnSnow(tile) != (tile_z > GetSnowLine())) {
+					ToggleSnow(tile);
+					MarkTileDirtyByTile(tile);
+				}
 			}
 			break;
 


### PR DESCRIPTION
## Motivation / Problem

Flat road foundations are right now getting the snowy state of the lower z-height. This makes them look visually disconnected from their surroundings.

**Before PR**
![Suningdore Transport, 15th Feb 2000](https://user-images.githubusercontent.com/61427715/165954565-cbdb291b-6540-4a45-9340-6ca50c3bd195.png)

**After PR**
![Suningdore Transport, 18th Jan 2000](https://user-images.githubusercontent.com/61427715/165954555-45337115-35d7-445b-b068-2b3f70167d1f.png)

## Description

Changing the GetTileZ to GetTileMaxZ in the case of flat tiles, including flat foundation tiles, the snow state is always the same as the visually connected tiles.

## Limitations

None

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
