### PR TITLE
Add GUI setting to show order occupancy by default

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1630,6 +1630,9 @@ STR_CONFIG_SETTING_DISABLE_WATER_ANIMATION_8X                   :8x zoom and abo
 STR_CONFIG_SETTING_DISABLE_WATER_ANIMATION_16X                  :16x zoom and above
 STR_CONFIG_SETTING_DISABLE_WATER_ANIMATION_32X                  :32x zoom and above
 
+STR_CONFIG_SETTING_SHOW_ORDER_OCCUPANCY_BY_DEFAULT              :Show order occupancy by default: {STRING2}
+STR_CONFIG_SETTING_SHOW_ORDER_OCCUPANCY_BY_DEFAULT_HELPTEXT     :Show detailed per-order occupancy by default when opening a vehicle's orders window
+
 STR_CONFIG_SETTING_ADV_SIG_BRIDGE_TUN_MODES                     :Enable signals on bridges/tunnels advanced modes: {STRING2}
 STR_CONFIG_SETTING_ADV_SIG_BRIDGE_TUN_MODES_HELPTEXT            :Enables use of advanced modes of signal simulation on bridges and tunnels. When disabled, bridges/tunnels which are not already in an advanced mode cannot be changed to an advanced mode, however other players may choose to enable this setting and use an advanced mode.
 

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -1624,7 +1624,9 @@ public:
 		this->CreateNestedTree();
 		this->vscroll = this->GetScrollbar(WID_O_SCROLLBAR);
 		if (v->owner == _local_company) {
-			this->GetWidget<NWidgetStacked>(WID_O_SEL_OCCUPANCY)->SetDisplayedPlane(SZSP_NONE);
+			this->GetWidget<NWidgetStacked>(WID_O_SEL_OCCUPANCY)->SetDisplayedPlane(_settings_client.gui.show_order_occupancy_by_default ? 0 : SZSP_NONE);
+			this->SetWidgetLoweredState(WID_O_OCCUPANCY_TOGGLE, _settings_client.gui.show_order_occupancy_by_default);
+
 			this->GetWidget<NWidgetStacked>(WID_O_SEL_COND_AUX)->SetDisplayedPlane(SZSP_NONE);
 			this->GetWidget<NWidgetStacked>(WID_O_SEL_COND_AUX2)->SetDisplayedPlane(SZSP_NONE);
 		}

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1935,6 +1935,7 @@ static SettingsContainer &GetSettingsTree()
 			interface->Add(new SettingEntry("gui.dual_pane_train_purchase_window"));
 			interface->Add(new SettingEntry("gui.allow_hiding_waypoint_labels"));
 			interface->Add(new SettingEntry("gui.disable_water_animation"));
+			interface->Add(new SettingEntry("gui.show_order_occupancy_by_default"));
 		}
 
 		SettingsPage *advisors = main->Add(new SettingsPage(STR_CONFIG_SETTING_ADVISORS));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -247,6 +247,7 @@ struct GUISettings : public TimeSettings {
 	bool   dual_pane_train_purchase_window;  ///< Dual pane train purchase window
 	bool   allow_hiding_waypoint_labels;     ///< Allow hiding waypoint viewport labels
 	uint8  disable_water_animation;          ///< Disable water animation depending on zoom level
+	bool   show_order_occupancy_by_default;  ///< Show order occupancy by default in vehicle order window
 
 	uint16 console_backlog_timeout;          ///< the minimum amount of time items should be in the console backlog before they will be removed in ~3 seconds granularity.
 	uint16 console_backlog_length;           ///< the minimum amount of items in the console backlog before items will be removed.

--- a/src/table/settings/settings.ini
+++ b/src/table/settings/settings.ini
@@ -5536,6 +5536,14 @@ str      = STR_CONFIG_SETTING_DISABLE_WATER_ANIMATION
 strhelp  = STR_CONFIG_SETTING_DISABLE_WATER_ANIMATION_HELPTEXT
 post_cb  = SpriteZoomMinChanged
 
+[SDTC_BOOL]
+var      = gui.show_order_occupancy_by_default
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
+def      = false
+str      = STR_CONFIG_SETTING_SHOW_ORDER_OCCUPANCY_BY_DEFAULT
+strhelp  = STR_CONFIG_SETTING_SHOW_ORDER_OCCUPANCY_BY_DEFAULT_HELPTEXT
+cat      = SC_BASIC
+
 ; For the dedicated build we'll enable dates in logs by default.
 [SDTC_BOOL]
 ifdef    = DEDICATED


### PR DESCRIPTION
Just a simple setting to turn it on by default, which I find very useful and avoids a lot of clicking on the % button manually. Note that I haven't touched OpenTTD's codebase in many years, so feel free to let me know if anything is wrong. Tested on/off values and confirmed working properly.

Cheers!