### PR TITLE
Various departure boards UI/UX bugfixes/improvements

### DIFF
--- a/src/departures_gui.cpp
+++ b/src/departures_gui.cpp
@@ -365,16 +365,19 @@ public:
 					this->RaiseWidget(widget);
 				}
 
-				if (!this->departure_types[0]) {
-					this->RaiseWidget(WID_DB_SHOW_VIA);
-					this->DisableWidget(WID_DB_SHOW_VIA);
-				} else {
-					this->EnableWidget(WID_DB_SHOW_VIA);
-
-					if (this->departure_types[2]) {
-						this->LowerWidget(WID_DB_SHOW_VIA);
+				/* Side effects */
+				if (widget == WID_DB_SHOW_DEPS) {
+					if (!this->departure_types[0]) {
+						this->RaiseWidget(WID_DB_SHOW_VIA);
+						this->DisableWidget(WID_DB_SHOW_VIA);
+					} else {
+						this->EnableWidget(WID_DB_SHOW_VIA);
+						this->SetWidgetLoweredState(WID_DB_SHOW_VIA,this->departure_types[2]);
 					}
+					/* Redraw required. */
+					this->SetWidgetDirty(WID_DB_SHOW_VIA);
 				}
+
 				/* We need to recompute the departures list. */
 				this->calc_tick_countdown = 0;
 				/* We need to redraw the button that was pressed. */

--- a/src/departures_gui.cpp
+++ b/src/departures_gui.cpp
@@ -337,11 +337,11 @@ public:
 				} else {
 					this->show_types[widget - WID_DB_SHOW_TRAINS] = !this->show_types[widget - WID_DB_SHOW_TRAINS];
 					this->SetWidgetLoweredState(widget, this->show_types[widget - WID_DB_SHOW_TRAINS]);
+					/* We need to redraw the button that was pressed. */
 					this->SetWidgetDirty(widget);
 				}
 				/* We need to recompute the departures list. */
 				this->RefreshVehicleList();
-				/* We need to redraw the button that was pressed. */
 				if (_pause_mode != PM_UNPAUSED) this->OnGameTick();
 				break;
 			}

--- a/src/departures_gui.cpp
+++ b/src/departures_gui.cpp
@@ -252,7 +252,7 @@ public:
 		this->RaiseWidget(WID_DB_SHOW_VIA);
 		this->LowerWidget(WID_DB_SHOW_PAX);
 		this->LowerWidget(WID_DB_SHOW_FREIGHT);
-		this->SetDepartureTypesDisabledState();
+		if (!Twaypoint) this->SetDepartureTypesDisabledState();
 		this->SetCargoFilterDisabledState();
 
 		for (uint i = 0; i < 4; ++i) {

--- a/src/departures_gui.cpp
+++ b/src/departures_gui.cpp
@@ -307,8 +307,8 @@ public:
 			case WID_DB_SHOW_SHIPS:
 			case WID_DB_SHOW_PLANES: {
 				uint64 params[1];
-				params[0] = STR_STATION_VIEW_SCHEDULED_TRAINS_TOOLTIP + (widget - WID_DB_SHOW_TRAINS);
-				GuiShowTooltips(this, STR_STATION_VIEW_SCHEDULED_TOOLTIP_CTRL_SUFFIX, 1, params, close_cond);
+				params[0] = STR_DEPARTURES_SHOW_TRAINS_TOOLTIP + (widget - WID_DB_SHOW_TRAINS);
+				GuiShowTooltips(this, STR_DEPARTURES_SHOW_TYPE_TOOLTIP_CTRL_SUFFIX, 1, params, close_cond);
 				return true;
 			}
 			default:

--- a/src/departures_gui.cpp
+++ b/src/departures_gui.cpp
@@ -336,12 +336,7 @@ public:
 					}
 				} else {
 					this->show_types[widget - WID_DB_SHOW_TRAINS] = !this->show_types[widget - WID_DB_SHOW_TRAINS];
-					if (this->show_types[widget - WID_DB_SHOW_TRAINS]) {
-						this->LowerWidget(widget);
-					}
-					else {
-						this->RaiseWidget(widget);
-					}
+					this->SetWidgetLoweredState(widget, this->show_types[widget - WID_DB_SHOW_TRAINS]);
 					this->SetWidgetDirty(widget);
 				}
 				/* We need to recompute the departures list. */
@@ -359,11 +354,7 @@ public:
 			case WID_DB_SHOW_VIA:
 
 				this->departure_types[widget - WID_DB_SHOW_DEPS] = !this->departure_types[widget - WID_DB_SHOW_DEPS];
-				if (this->departure_types[widget - WID_DB_SHOW_DEPS]) {
-					this->LowerWidget(widget);
-				} else {
-					this->RaiseWidget(widget);
-				}
+				this->SetWidgetLoweredState(widget, this->departure_types[widget - WID_DB_SHOW_DEPS]);
 
 				/* Side effects */
 				if (widget == WID_DB_SHOW_DEPS) {
@@ -372,7 +363,7 @@ public:
 						this->DisableWidget(WID_DB_SHOW_VIA);
 					} else {
 						this->EnableWidget(WID_DB_SHOW_VIA);
-						this->SetWidgetLoweredState(WID_DB_SHOW_VIA,this->departure_types[2]);
+						this->SetWidgetLoweredState(WID_DB_SHOW_VIA, this->departure_types[2]);
 					}
 					/* Redraw required. */
 					this->SetWidgetDirty(WID_DB_SHOW_VIA);

--- a/src/departures_gui.cpp
+++ b/src/departures_gui.cpp
@@ -467,7 +467,7 @@ public:
 			this->DeleteDeparturesList(this->arrivals);
 			bool show_pax = _settings_client.gui.departure_only_passengers ? true : this->show_pax;
 			bool show_freight = _settings_client.gui.departure_only_passengers ? false : this->show_freight;
-			this->departures = (this->departure_types[0] ? MakeDepartureList(this->station, this->vehicles, D_DEPARTURE, Twaypoint || this->departure_types[2], show_pax, show_freight) : new DepartureList());
+			this->departures = (this->departure_types[0] || _settings_client.gui.departure_show_both ? MakeDepartureList(this->station, this->vehicles, D_DEPARTURE, Twaypoint || this->departure_types[2], show_pax, show_freight) : new DepartureList());
 			this->arrivals   = (this->departure_types[1] && !_settings_client.gui.departure_show_both ? MakeDepartureList(this->station, this->vehicles, D_ARRIVAL, false, show_pax, show_freight) : new DepartureList());
 			this->departures_invalid = false;
 			this->SetWidgetDirty(WID_DB_LIST);

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4675,8 +4675,8 @@ STR_DEPARTURES_FREIGHT                                          :{BLACK}{TINY_FO
 STR_DEPARTURES_DEPARTURES                                       :{BLACK}{TINY_FONT}D
 STR_DEPARTURES_ARRIVALS                                         :{BLACK}{TINY_FONT}A
 STR_DEPARTURES_VIA_BUTTON                                       :{BLACK}{TINY_FONT}via
-STR_DEPARTURES_PAX_TOOLTIP                                      :{BLACK}Show passenger departures
-STR_DEPARTURES_FREIGHT_TOOLTIP                                  :{BLACK}Show freight departures
+STR_DEPARTURES_PAX_TOOLTIP                                      :{BLACK}Show passenger arrivals/departures
+STR_DEPARTURES_FREIGHT_TOOLTIP                                  :{BLACK}Show freight arrivals/departures
 STR_DEPARTURES_DEPARTURES_TOOLTIP                               :{BLACK}Show timetabled departures
 STR_DEPARTURES_ARRIVALS_TOOLTIP                                 :{BLACK}Show timetabled arrivals
 STR_DEPARTURES_VIA_TOOLTIP                                      :{BLACK}Show timetabled vehicles that do not stop here
@@ -4733,20 +4733,20 @@ STR_DEPARTURES_CANCELLED                                        :{RED}Cancelled
 
 ############ config settings
 STR_CONFIG_SETTING_DEPARTUREBOARDS                              :{ORANGE}Departure boards
-STR_CONFIG_MAX_DEPARTURES                                       :Show at most {STRING2} departures at each station
-STR_CONFIG_MAX_DEPARTURES_HELPTEXT                              :The maximum number of departures to show on a departure board
-STR_CONFIG_MAX_DEPARTURE_TIME                                   :Show departures at most {STRING2} days in advance
-STR_CONFIG_MAX_DEPARTURE_TIME_HELPTEXT                          :How far in advance to show departures, in days
-STR_CONFIG_DEPARTURE_CALC_FREQUENCY                             :Calculate departures every {STRING2} ticks
-STR_CONFIG_DEPARTURE_CALC_FREQUENCY_HELPTEXT                    :How frequently to refresh a list of departures, in ticks
-STR_CONFIG_DEPARTURE_VEHICLE_NAME                               :Show vehicle name with departures: {STRING2}
-STR_CONFIG_DEPARTURE_VEHICLE_NAME_HELPTEXT                      :Whether to show vehicle names next to their departures
-STR_CONFIG_DEPARTURE_GROUP_NAME                                 :Show group name with departures: {STRING2}
-STR_CONFIG_DEPARTURE_GROUP_NAME_HELPTEXT                        :Whether to show names of groups that a vehicle belongs to next to its departures
-STR_CONFIG_DEPARTURE_COMPANY_NAME                               :Show company name with departures: {STRING2}
-STR_CONFIG_DEPARTURE_COMPANY_NAME_HELPTEXT                      :Whether to show a company's name next to its vehicles' departures
-STR_CONFIG_DEPARTURE_VEHICLE_TYPE                               :Show vehicle type icon with departures: {STRING2}
-STR_CONFIG_DEPARTURE_VEHICLE_TYPE_HELPTEXT                      :Whether to show a vehicle's type as an icon next to its departures
+STR_CONFIG_MAX_DEPARTURES                                       :Show at most {STRING2} departure board entries for each station
+STR_CONFIG_MAX_DEPARTURES_HELPTEXT                              :The maximum number of entries to show on a departure board
+STR_CONFIG_MAX_DEPARTURE_TIME                                   :Show arrivals/departures at most {STRING2} days in advance
+STR_CONFIG_MAX_DEPARTURE_TIME_HELPTEXT                          :How far in advance to show arrivals and departures, in days
+STR_CONFIG_DEPARTURE_CALC_FREQUENCY                             :Calculate departure board entries every {STRING2} ticks
+STR_CONFIG_DEPARTURE_CALC_FREQUENCY_HELPTEXT                    :How frequently to refresh a list of arrivals/departures, in ticks
+STR_CONFIG_DEPARTURE_VEHICLE_NAME                               :Show vehicle name in entries: {STRING2}
+STR_CONFIG_DEPARTURE_VEHICLE_NAME_HELPTEXT                      :Whether to show vehicle names in their departure board entries
+STR_CONFIG_DEPARTURE_GROUP_NAME                                 :Show group name in entries: {STRING2}
+STR_CONFIG_DEPARTURE_GROUP_NAME_HELPTEXT                        :Whether to show names of groups that a vehicle belongs to in its departure board entries
+STR_CONFIG_DEPARTURE_COMPANY_NAME                               :Show company name in entries: {STRING2}
+STR_CONFIG_DEPARTURE_COMPANY_NAME_HELPTEXT                      :Whether to show a company's name in its vehicles' departure board entries
+STR_CONFIG_DEPARTURE_VEHICLE_TYPE                               :Show vehicle type icon in entries: {STRING2}
+STR_CONFIG_DEPARTURE_VEHICLE_TYPE_HELPTEXT                      :Whether to show a vehicle's type as an icon in its departure board entries
 STR_CONFIG_DEPARTURE_VEHICLE_COLOR                              :Show vehicle type icon in silver: {STRING2}
 STR_CONFIG_DEPARTURE_VEHICLE_COLOR_HELPTEXT                     :Whether to show vehicle type icons in silver
 STR_CONFIG_DEPARTURE_LARGER_FONT                                :Use larger font for stations called at on departure boards: {STRING2}
@@ -4754,20 +4754,20 @@ STR_CONFIG_DEPARTURE_LARGER_FONT_HELPTEXT                       :Whether to use 
 STR_CONFIG_DEPARTURE_DESTINATION_TYPE                           :Show icons for destinations that are docks or airports: {STRING2}
 STR_CONFIG_DEPARTURE_DESTINATION_TYPE_HELPTEXT                  :Whether to show icons next to destinations that are docks or airports
 STR_CONFIG_DEPARTURE_SHOW_BOTH                                  :Show arrival and departure times on the same line: {STRING2}
-STR_CONFIG_DEPARTURE_SHOW_BOTH_HELPTEXT                         :Whether to show both arrival and departure times next to departures
-STR_CONFIG_DEPARTURE_ONLY_PASSENGERS                            :Only show departures for vehicles that can carry passengers: {STRING2}
-STR_CONFIG_DEPARTURE_ONLY_PASSENGERS_HELPTEXT                   :Whether to only show departures of vehicles that can carry passengers
+STR_CONFIG_DEPARTURE_SHOW_BOTH_HELPTEXT                         :Whether arrival and departure times for a vehicle are combined into a single entry instead of being listed separately
+STR_CONFIG_DEPARTURE_ONLY_PASSENGERS                            :Only show entries for vehicles that can carry passengers: {STRING2}
+STR_CONFIG_DEPARTURE_ONLY_PASSENGERS_HELPTEXT                   :Whether to only show arrivals and departures of vehicles that can carry passengers
 STR_CONFIG_DEPARTURE_SMART_TERMINUS                             :Don't show termini that can be reached sooner on a later vehicle: {STRING2}
 STR_CONFIG_DEPARTURE_SMART_TERMINUS_HELPTEXT                    :Whether to show termini that can be reached sooner on another vehicle that departs later
 STR_CONFIG_DEPARTURE_CONDITIONALS                               :Handle conditional order jumps by: {STRING2}
-STR_CONFIG_DEPARTURE_CONDITIONALS_HELPTEXT                      :How conditional orders should be dealt with when calculating departures
+STR_CONFIG_DEPARTURE_CONDITIONALS_HELPTEXT                      :How conditional orders should be dealt with when calculating departure board entries
 STR_CONFIG_DEPARTURE_CONDITIONALS_1                             :giving up
 STR_CONFIG_DEPARTURE_CONDITIONALS_2                             :assuming they will be taken
 STR_CONFIG_DEPARTURE_CONDITIONALS_3                             :assuming they will not be taken
 STR_CONFIG_DEPARTURE_SHOW_ALL_STOPS                             :Show all stations called at regardless of loading/unloading: {STRING2}
 STR_CONFIG_DEPARTURE_SHOW_ALL_STOPS_HELPTEXT                    :Whether stations that a vehicle only loads from will be shown in the calling at list
-STR_CONFIG_DEPARTURE_MERGE_IDENTICAL                            :Merge identical departures: {STRING2}
-STR_CONFIG_DEPARTURE_MERGE_IDENTICAL_HELPTEXT                   :Whether identical departures should be merged into a single departure
+STR_CONFIG_DEPARTURE_MERGE_IDENTICAL                            :Merge identical entries: {STRING2}
+STR_CONFIG_DEPARTURE_MERGE_IDENTICAL_HELPTEXT                   :Whether identical departure board entries should be merged into a single one
 
 # Waypoint/buoy view window
 STR_WAYPOINT_VIEW_CAPTION                                       :{WHITE}{WAYPOINT}

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4662,7 +4662,6 @@ STR_STATION_VIEW_SCHEDULED_TRAINS_TOOLTIP                       :{BLACK}Show all
 STR_STATION_VIEW_SCHEDULED_ROAD_VEHICLES_TOOLTIP                :{BLACK}Show all road vehicles which have this station on their schedule
 STR_STATION_VIEW_SCHEDULED_AIRCRAFT_TOOLTIP                     :{BLACK}Show all aircraft which have this station on their schedule
 STR_STATION_VIEW_SCHEDULED_SHIPS_TOOLTIP                        :{BLACK}Show all ships which have this station on their schedule
-STR_STATION_VIEW_SCHEDULED_TOOLTIP_CTRL_SUFFIX                  :{BLACK}{STRING}. Ctrl+Click to show exclusively.
 
 STR_STATION_VIEW_RENAME_STATION_CAPTION                         :Rename station/loading area
 STR_STATION_VIEW_CLOSE_AIRPORT                                  :{BLACK}Close airport
@@ -4681,6 +4680,11 @@ STR_DEPARTURES_FREIGHT_TOOLTIP                                  :{BLACK}Show fre
 STR_DEPARTURES_DEPARTURES_TOOLTIP                               :{BLACK}Show timetabled departures
 STR_DEPARTURES_ARRIVALS_TOOLTIP                                 :{BLACK}Show timetabled arrivals
 STR_DEPARTURES_VIA_TOOLTIP                                      :{BLACK}Show timetabled vehicles that do not stop here
+STR_DEPARTURES_SHOW_TRAINS_TOOLTIP                              :{BLACK}Show upcoming trains on this station's timetable
+STR_DEPARTURES_SHOW_ROAD_VEHICLES_TOOLTIP                       :{BLACK}Show upcoming road vehicles on this station's timetable
+STR_DEPARTURES_SHOW_SHIPS_TOOLTIP                               :{BLACK}Show upcoming ships on this station's timetable
+STR_DEPARTURES_SHOW_AIRCRAFT_TOOLTIP                            :{BLACK}Show upcoming aircraft on this station's timetable
+STR_DEPARTURES_SHOW_TYPE_TOOLTIP_CTRL_SUFFIX                    :{BLACK}{STRING}. Ctrl+Click to show exclusively.
 STR_DEPARTURES_EMPTY                                            :{ORANGE}No vehicles are currently timetabled for this station.
 STR_DEPARTURES_NONE_SELECTED                                    :{ORANGE}No timetable information has been requested.
 STR_DEPARTURES_TIME                                             :{ORANGE}{DATE_WALLCLOCK_TINY}


### PR DESCRIPTION
### Bug: "Show via" widget not redrawn when state is changed as a side effect

The "Show via" widget gets enabled/disabled as a side effect of "Show departures" being toggled, but it was not being marked dirty for redrawing, leading to some strange behavior.

### Refactor widget raised/lowered toggling

`LowerWidget` and `RaiseWidget` both simply wrap `SetWidgetLoweredState`, so we can eliminate conditional test and nested call by passing the boolean directly to the latter. Code readability unaffected.
 
### Bug: "Show ships" and "Show aircraft" widget tooltips reversed

The ordering of strings did not match the ordering of widget enum. Could be fixed by switching the ordering, but instead prefer to ...(see next)

### Enhancement: dedicated tooltip text for "Show &lt;vehicle type&gt;" widgets

Add dedicated tooltip text for these four widgets, `STR_DEPARTURES_SHOW_*_TOOLTIP`, instead of repurposing `STR_STATION_VIEW_SCHEDULED_*_TOOLTIP` which are for a different window (see `station_gui.cpp`). This lets us change the wording to something more accurate and appropriate to this context. For instance, number of entries on departure board is capped (default: 10) so more accurate to refer to "upcoming" arriving/departing vehicles rather than "all" vehicles; same vehicle may show multiple times on the departure board; etc. Meaning of the text may be even more inaccurate for translations in other languages.

Also renamed `STR_STATION_VIEW_SCHEDULED_TOOLTIP_CTRL_SUFFIX` to `STR_DEPARTURES_SHOW_TYPE_TOOLTIP_CTRL_SUFFIX` accordingly; as far as I can tell it is only used in departure boards and not station view.

### Bug: stuck with empty list if `departure_show_both` setting switched on while "Show departures" is off on existing window

If you have a departure board already open and set to show only arrivals and not departures, going to settings and turning `departure_show_both` on leaves you with an empty listing. Since this also disables the "Show arrivals" and "Show departures" widgets, you are forced to go back and ensure "Show departures" is turned on before changing the config setting.

### Enhancement: more intuitive "Show arrivals" and "Show departures" widget lowered state while disabled

Related to the previous, when `departure_show_both` setting is on, besides disabling "Show arrivals" and "Show departures" widgets, also force them to be in the lowered state. This is a more intuitive reflection of the behavior experienced by the end user -- both are being shown -- even though internally the implementation subtleties are somewhat different (put arrival times in departure entries; don't show arrivals independently).