### PR TITLE
Add script for updating translations

### DIFF
--- a/src/lang/extra/_checkMissingTranslations.sh
+++ b/src/lang/extra/_checkMissingTranslations.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+if [ $# -eq 0 ]; then
+   echo "Please specify a language file to update"
+   exit 1
+fi
+
+language_file="$1"
+
+# Check that the specified file exists
+if [ ! -f "$language_file" ]; then
+   echo "File not found: $language_file"
+   exit 1
+fi
+
+# Read each line from the English file and check if it exists in the language file
+while read -r line; do
+   # Skip lines that start with #
+   if [[ $line =~ ^#.* ]]; then
+      continue
+   fi
+   # Extract the string code from the English line
+   STRING_CODE=$(echo $line | cut -d' ' -f1)
+   # Check if the string code exists in the language file
+   if ! grep -qw "$STRING_CODE" "$language_file"; then
+      # If the line doesn't exist, add it to the end of the language file
+      continue
+      echo "$line" >>"$language_file"
+      echo "Added missing line to $language_file: $line"
+   fi
+done <"english.txt"

--- a/src/lang/extra/_checkMissingTranslations.sh
+++ b/src/lang/extra/_checkMissingTranslations.sh
@@ -13,9 +13,20 @@ if [ ! -f "$language_file" ]; then
    exit 1
 fi
 
+in_override_section="true"
 # Read each line from the English file and check if it exists in the language file
 while read -r line; do
-   # Skip lines that start with #
+   # Check if we have reached the end of the override section
+   if [[ $line == "##override off" ]]; then
+      in_override_section="false"
+      continue
+   fi
+
+   # Skip lines before the end of the override section
+   if [[ $in_override_section == "true" ]]; then
+      continue
+   fi
+   # Skip other lines that start with #
    if [[ $line =~ ^#.* ]]; then
       continue
    fi

--- a/src/lang/extra/_checkMissingTranslations.sh
+++ b/src/lang/extra/_checkMissingTranslations.sh
@@ -20,11 +20,10 @@ while read -r line; do
       continue
    fi
    # Extract the string code from the English line
-   STRING_CODE=$(echo $line | cut -d' ' -f1)
+   STRING_CODE=$(echo $line | cut -d':' -f1 | tr -d '[:space:]')
    # Check if the string code exists in the language file
-   if ! grep -qw "$STRING_CODE" "$language_file"; then
+   if ! grep -q "$STRING_CODE" "$language_file"; then
       # If the line doesn't exist, add it to the end of the language file
-      continue
       echo "$line" >>"$language_file"
       echo "Added missing line to $language_file: $line"
    fi

--- a/utils/checkMissingTranslations.sh
+++ b/utils/checkMissingTranslations.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
+git_top_level=$(git rev-parse --show-toplevel)
+
 if [ $# -eq 0 ]; then
-   echo "Please specify a language file to update"
+   echo "Please specify a language to update"
    exit 1
 fi
 
-language_file="$1"
+language_file="$git_top_level/src/lang/extra/$1.txt"
 
 # Check that the specified file exists
 if [ ! -f "$language_file" ]; then
@@ -38,4 +40,6 @@ while read -r line; do
       echo "$line" >>"$language_file"
       echo "Added missing line to $language_file: $line"
    fi
-done <"english.txt"
+done <"$git_top_level/src/lang/extra/english.txt"
+cd $git_top_level/src/lang/
+perl $git_top_level/utils/conv-lang.pl

--- a/utils/conv-lang.pl
+++ b/utils/conv-lang.pl
@@ -1,0 +1,123 @@
+
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use utf8;
+
+use File::Slurp;
+
+my @langs = qw(
+afrikaans.txt
+arabic_egypt.txt
+basque.txt
+belarusian.txt
+brazilian_portuguese.txt
+bulgarian.txt
+catalan.txt
+chuvash.txt
+croatian.txt
+czech.txt
+danish.txt
+dutch.txt
+english_AU.txt
+english_US.txt
+esperanto.txt
+estonian.txt
+faroese.txt
+finnish.txt
+french.txt
+frisian.txt
+gaelic.txt
+galician.txt
+german.txt
+greek.txt
+hebrew.txt
+hindi.txt
+hungarian.txt
+icelandic.txt
+ido.txt
+indonesian.txt
+irish.txt
+italian.txt
+japanese.txt
+korean.txt
+latin.txt
+latvian.txt
+lithuanian.txt
+luxembourgish.txt
+macedonian.txt
+malay.txt
+maltese.txt
+marathi.txt
+norwegian_bokmal.txt
+norwegian_nynorsk.txt
+persian.txt
+polish.txt
+portuguese.txt
+romanian.txt
+russian.txt
+serbian.txt
+simplified_chinese.txt
+slovak.txt
+slovenian.txt
+spanish.txt
+spanish_MX.txt
+swedish.txt
+tamil.txt
+thai.txt
+traditional_chinese.txt
+turkish.txt
+urdu.txt
+ukrainian.txt
+vietnamese.txt
+welsh.txt
+);
+
+
+my @lang_lines;
+
+my $start = 0;
+my @lines = read_file("extra/english.txt") or die("Can't read english.txt");
+for (@lines) {
+	$start = 1 if /##override off/;
+	next unless $start;
+
+	next if /^##/;
+
+	push @lang_lines, $_;
+}
+
+
+for my $lang (@langs) {
+	my @in_lines = read_file($lang);
+	push @in_lines, read_file("extra/$lang");
+
+	my %strs;
+	for (@in_lines) {
+		chomp;
+		next if /^#/;
+
+		if (/^(\w+)\s*:/) {
+			$strs{$1} = $_;
+		}
+	}
+
+	my @lines;
+	my $suppress_whitespace = 1;
+	for (@lang_lines) {
+		if (/^(\w+)\s*:/) {
+			if ($strs{$1}) {
+				push @lines, $strs{$1} . "\n";
+				$suppress_whitespace = 0;
+			}
+		} else {
+			next if ($_ eq "\n") && $suppress_whitespace;
+			push @lines, $_;
+			$suppress_whitespace = ($_ eq "\n");
+		}
+	}
+	pop @lines if ($lines[-1] eq "\n");
+	write_file("extra/$lang", @lines);
+}


### PR DESCRIPTION
## Motivation / Problem

Now that the JGR extra translations are on a different file. I've made a script to get the strings missing on any language file and add them at the end of the file in order to update the translations

## Description

It's just a self-explanatory bash script that asks for a language file, in example `galician.txt` and checks each line that is not a comment (beginning with #) on the `english.txt` file. If it founds a missing string (by the string language code), it adds the full line at the end of the language file you are checking, so you can later open it and translate it.

## Limitations

It doesn't replace the codes `STRING1,STRING2,STRING3, RAW_STRING `and so on, so the translator should check them and build the translations to check them.

## Checklist for review

I've added the bash script inside the extra folder for convenience, but perhaps it should go on other place. Or perhaps it doesn't even have a place on the repo at all. Anyway I wanted to share it with you in case you find it useful :-) 