### PR TITLE
Feature: A setting to bring back old tile tooltip behavior.

### DIFF
--- a/src/lang/extra/english.txt
+++ b/src/lang/extra/english.txt
@@ -2121,3 +2121,6 @@ STR_TOWN_DIRECTORY_INFO                                         :{BLACK}{STRING1
 
 STR_GAME_OPTIONS_GUI_SCALE_MAIN_TOOLBAR                         :{BLACK}Bigger main toolbar
 STR_GAME_OPTIONS_GUI_SCALE_MAIN_TOOLBAR_TOOLTIP                 :{BLACK}Check this box to increase the scale of the main toolbar
+
+STR_CONFIG_SETTING_INSTANT_TILE_TOOLTIP                         :Show tooltips for tiles without a right-click: {STRING2}
+STR_CONFIG_SETTING_INSTANT_TILE_TOOLTIP_HELPTEXT                :Allow tooltips for tiles, such as industries, to show without the need for a right-click, if latter is set to be necessary for all tooltips.

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -528,7 +528,8 @@ struct MainWindow : Window
 
 	virtual void OnMouseOver(Point pt, int widget) override
 	{
-		if (pt.x != -1 && _game_mode != GM_MENU && (_settings_client.gui.hover_delay_ms == 0 ? _right_button_down : _mouse_hovering)) {
+		if (pt.x != -1 && _game_mode != GM_MENU &&
+			(_settings_client.gui.hover_delay_ms == 0 && (_right_button_down || _settings_client.gui.instant_tile_tooltip) || _mouse_hovering)) {
 			/* Show tooltip with last month production or town name */
 			const Point p = GetTileBelowCursor();
 			const TileIndex tile = TileVirtXY(p.x, p.y);

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1924,6 +1924,7 @@ static SettingsContainer &GetSettingsTree()
 			{
 				general->Add(new SettingEntry("gui.osk_activation"));
 				general->Add(new SettingEntry("gui.hover_delay_ms"));
+				general->Add(new SettingEntry("gui.instant_tile_tooltip"));
 				general->Add(new SettingEntry("gui.errmsg_duration"));
 				general->Add(new SettingEntry("gui.window_snap_radius"));
 				general->Add(new SettingEntry("gui.window_soft_limit"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -132,6 +132,7 @@ struct GUISettings : public TimeSettings {
 	uint8  auto_scrolling;                   ///< scroll when moving mouse to the edge (see #ViewportAutoscrolling)
 	byte   errmsg_duration;                  ///< duration of error message
 	uint16 hover_delay_ms;                   ///< time required to activate a hover event, in milliseconds
+	bool   instant_tile_tooltip;             ///< don't require a right click to activate a hover event to show a tooltip for an in-game tile (e.g. industry).
 	bool   link_terraform_toolbar;           ///< display terraform toolbar when displaying rail, road, water and airport toolbars
 	uint8  smallmap_land_colour;             ///< colour used for land and heightmap at the smallmap
 	uint8  scroll_mode;                      ///< viewport scroll mode

--- a/src/table/settings/settings.ini
+++ b/src/table/settings/settings.ini
@@ -4544,6 +4544,13 @@ str      = STR_CONFIG_SETTING_HOVER_DELAY
 strhelp  = STR_CONFIG_SETTING_HOVER_DELAY_HELPTEXT
 strval   = STR_CONFIG_SETTING_HOVER_DELAY_VALUE
 
+[SDTC_BOOL]
+var     = gui.instant_tile_tooltip
+flags   = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
+def     = true
+str     = STR_CONFIG_SETTING_INSTANT_TILE_TOOLTIP
+strhelp = STR_CONFIG_SETTING_INSTANT_TILE_TOOLTIP_HELPTEXT
+
 [SDTC_OMANY]
 var      = gui.osk_activation
 type     = SLE_UINT8

--- a/src/viewport_gui.cpp
+++ b/src/viewport_gui.cpp
@@ -158,7 +158,7 @@ public:
 
 	virtual void OnMouseOver(Point pt, int widget) override
 	{
-		if (pt.x != -1 && (_settings_client.gui.hover_delay_ms == 0 ? _right_button_down : _mouse_hovering)) {
+		if (pt.x != -1 && (_settings_client.gui.hover_delay_ms == 0 && (_right_button_down || _settings_client.gui.instant_tile_tooltip) || _mouse_hovering)) {
 			/* Show tooltip with last month production or town name */
 			const Point p = GetTileBelowCursor();
 			const TileIndex tile = TileVirtXY(p.x, p.y);


### PR DESCRIPTION
If enabled, the setting allows tooltips for tiles, such as industries, to show instantly, when otherwise they would require a right-click.

## Motivation / Problem

One of the features in this patchpack is showing tooltips when hovering over tiles on the map. In ancient days it used to be that , if "Show tooltips" setting was set to "Right-click", a right-click would only be required to show a tooltip for an interface widget, while hovering over, for example, an industry would show a tooltip instantly. This was fixed in v0.47.1 release, creating 2 problems:

1. There is a difference between utility of interface and town/industry tooltips for the player. The former provides information that, generally, only changes with updates to the program, while the latter provides real-time gameplay information that may frequently change throughout the game. This means that there is a good reason for the player to want to have widget tooltips to be right-click-only, so they don't create visual clutter with info that is already known, while allowing instant access to latest updates to industry production rates. The above-mentioned change prevents this.
2. Requiring a right-click on a tile to see a tooltip conflicts with how OpenTTD handles scrolling. In order for a tooltip to be shown, a "OnMouseOver" function must be called, but that doesn't happen if a player is moving the map or a viewport. This means, that in order for a tooltip to show for a tile with a right-click, the scrolling must be bound to the left mouse button, which is 1 scrolling mode out of 4. In other words, in most scrolling modes, setting tooltips to show on a right-click, effectively disables town/industry ones.

## Description

This adds an advanced setting to instantly show tile tooltips, if "Show tooltips" setting is set to "Right-click". It's located in "Interface/General" and is called "Show tooltips for tiles without a right-click". It's enabled by default to avoid the most likely situation where a "Right-click" setting confuses the player into believing that town/industry tooltips are incompatible with it.

## Limitations

Some things I've noted when implementing this feature:
* There appears to be code for station rating tooltips, but it doesn't appear to work for me. I've updated the if condition for it regardless.
* There could be 2 separate settings for widget and tile tooltips, but I chose to not go that far. Same with allowing "MouseOver" events to during scrolling.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
