### PR TITLE
Fix some typos in jgrpp-changelog.md

### DIFF
--- a/jgrpp-changelog.md
+++ b/jgrpp-changelog.md
@@ -8,9 +8,9 @@
 * Fix requests to the online content service using an out of date vanilla version.
 * Fix sound output for linux-generic release builds.
 * Fix multi-cargo ships not showing all cargos in the build vehicle window.
-* Fix dual pane purchase window with mixed wagon/enginge variant trees.
+* Fix dual pane purchase window with mixed wagon/engine variant trees.
 * Fix text rendering with 8bpp-simple blitter.
-* Fix crash which could due to order backups not correctly restoring dispatch schedules when it was not enabled.
+* Fix crash which could be due to order backups not correctly restoring dispatch schedules when it was not enabled.
 * Fix scheduled dispatch being used for predicted arrival/departure times in the timetable window when it was not enabled.
 * Fix using default graphics for all signals and recolouring of signal posts when using an original TTD baseset.
 * Add/extend viewport tooltips for stations, waypoints, industries, depots and town tiles.


### PR DESCRIPTION
## Motivation / Problem

Two typos introduced in the changelog for JGRPP 0.54.3.

## Description

Fixed both typos.

## Limitations

None.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
