### PR TITLE
Add an optional "(City)" in Viewport labels

### DIFF
--- a/src/lang/extra/english.txt
+++ b/src/lang/extra/english.txt
@@ -2167,5 +2167,11 @@ STR_CONFIG_SETTING_STATION_RATING_TOOLTIP_MODE_OFF              :Off
 STR_CONFIG_SETTING_STATION_RATING_TOOLTIP_MODE_SIMPLE           :Simple
 STR_CONFIG_SETTING_STATION_RATING_TOOLTIP_MODE_DETAILED         :Detailed
 
+STR_CONFIG_SETTING_CITY_IN_LABEL                                :Show city in town name label: {STRING2}
+STR_CONFIG_SETTING_CITY_IN_LABEL_HELPTEXT                       :Display if a town is also a city in their label on the map
+
+###length 4
 STR_VIEWPORT_TOWN_COLOUR                                        :{1:SET_COLOUR}{0:TOWN}
 STR_VIEWPORT_TOWN_COLOUR_POP                                    :{WHITE}{TOWN} {SET_COLOUR}({COMMA})
+STR_VIEWPORT_TOWN_COLOUR_CITY                                   :{1:SET_COLOUR}{0:TOWN} (City)
+STR_VIEWPORT_TOWN_COLOUR_CITY_POP                               :{WHITE}{TOWN} {SET_COLOUR}(City, {COMMA})

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -2039,6 +2039,7 @@ static SettingsContainer &GetSettingsTree()
 				viewports->Add(new SettingEntry("gui.right_mouse_btn_emulation"));
 #endif
 				viewports->Add(new SettingEntry("gui.population_in_label"));
+				viewports->Add(new SettingEntry("gui.city_in_label"));
 				viewports->Add(new SettingEntry("gui.liveries"));
 				viewports->Add(new SettingEntry("gui.measure_tooltip"));
 				viewports->Add(new SettingEntry("gui.loading_indicators"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -181,6 +181,7 @@ struct GUISettings : public TimeSettings {
 	byte   max_num_lt_autosaves;             ///< controls how many long-term autosavegames are made before the game starts to overwrite (names them 0 to max_num_lt_autosaves - 1)
 	uint8  savegame_overwrite_confirm;       ///< Mode for when to warn about overwriting an existing savegame
 	bool   population_in_label;              ///< show the population of a town in its label?
+	bool   city_in_label;                    ///< show cities in label?
 	uint8  right_mouse_btn_emulation;        ///< should we emulate right mouse clicking?
 	uint8  scrollwheel_scrolling;            ///< scrolling using the scroll wheel?
 	uint8  scrollwheel_multiplier;           ///< how much 'wheel' per incoming event from the OS?

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1938,9 +1938,7 @@ static char *FormatString(char *buff, const char *str_arg, StringParameters *arg
 
 				bool tiny = (b == SCC_VIEWPORT_TOWN_LABEL2);
 				StringID string_id = STR_VIEWPORT_TOWN_COLOUR;
-				if (!tiny && HasBit(data, 40)) {
-					string_id = STR_VIEWPORT_TOWN_COLOUR_POP;
-				}
+				if (!tiny) string_id += GB(data, 40, 2);
 				int64 args_array[] = {t, GB(data, 32, 8), GB(data, 0, 32)};
 				StringParameters tmp_params(args_array);
 				buff = GetStringWithArgs(buff, string_id, &tmp_params, last);

--- a/src/table/settings/settings.ini
+++ b/src/table/settings/settings.ini
@@ -4763,6 +4763,14 @@ strhelp  = STR_CONFIG_SETTING_POPULATION_IN_LABEL_HELPTEXT
 post_cb  = [](auto) { UpdateAllTownVirtCoords(); }
 
 [SDTC_BOOL]
+var      = gui.city_in_label
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
+def      = false
+str      = STR_CONFIG_SETTING_CITY_IN_LABEL
+strhelp  = STR_CONFIG_SETTING_CITY_IN_LABEL_HELPTEXT
+post_cb  = [](auto) { UpdateAllTownVirtCoords(); }
+
+[SDTC_BOOL]
 var      = gui.link_terraform_toolbar
 flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = false

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -244,6 +244,7 @@ uint64 Town::LabelParam2() const
 		SB(value, 32, 8, TC_WHITE);
 	}
 	if (_settings_client.gui.population_in_label) SetBit(value, 40);
+	if (_settings_client.gui.city_in_label && this->larger_town) SetBit(value, 41);
 	return value;
 }
 


### PR DESCRIPTION
## Motivation / Problem

I was watching [Master Hellish's S10 Let's play](https://www.youtube.com/playlist?list=PLX9TPVcxrORNGh7hpvm0tLwAQNLizP9Qe)

And noticed that City Builder Script had a ".::City::." label on the cities, and thought this would be a handy feature on every game, especially when trying to find Cities quickly (say when comparing two towns with the same resources, and wanting to know what one to invest in at a glance).


<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Provides a "City in Label" option similar to "Population in Label" option.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->

I'm `woobilicious` on the discord.

## Limitations
Needs translations.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
