### PR TITLE
Update openttd.desktop -> add "+JGRPP" to app name

### DIFF
--- a/media/openttd.desktop
+++ b/media/openttd.desktop
@@ -2,7 +2,7 @@
 [Desktop Entry]
 Type=Application
 Version=1.0
-Name=OpenTTD
+Name=OpenTTD+JGRPP
 Icon=${BINARY_NAME}
 Exec=${BINARY_NAME}
 Terminal=false


### PR DESCRIPTION
Add JGRPP to application name to distinguish openttd+JGRPP from vanilla openttd

## Motivation / Problem

If both vanilla openttd and jgrpp are installed in parallel, both launchers have the same name in the applications menu 

## Description

change the application name in the desktop file to make Jjgrpp distinguishable from vanilla openttd

## Limitations

none

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
