### PR TITLE
Fix 2bb5c9ac84: typo in disable script parameter randomisation helptext

### DIFF
--- a/src/lang/extra/english.txt
+++ b/src/lang/extra/english.txt
@@ -2299,7 +2299,7 @@ STR_CONFIG_SETTING_CITY_IN_LABEL_HELPTEXT                       :Display if a to
 STR_CONFIG_SETTING_CYCLE_SIGNAL_PBS                             :Path signals only
 
 STR_CONFIG_SETTING_SCRIPT_DISABLE_PARAM_RANDOM                  :Disable script parameter randomisation: {STRING2}
-STR_CONFIG_SETTING_SCRIPT_DISABLE_PARAM_RANDOM_HELPTEXT         :Disable the randomisation of AI/GS script paraneters.
+STR_CONFIG_SETTING_SCRIPT_DISABLE_PARAM_RANDOM_HELPTEXT         :Disable the randomisation of AI/GS script parameters.
 
 STR_CONFIG_SETTING_RESTRICT_PATCH                               :Non-standard settings which are not in vanilla OpenTTD
 


### PR DESCRIPTION
## Motivation / Problem

A typo introduced in 2bb5c9ac848d5ab3ebbe08ef82880ef406aad205.

## Description

Fixed the typo.

## Limitations

None

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
