### PR TITLE
Feature: orderlist Importing / Exporting.

### DIFF
--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -43,6 +43,7 @@ static const char * const _subdirs[] = {
 	"save" PATHSEP "autosave" PATHSEP,
 	"scenario" PATHSEP,
 	"scenario" PATHSEP "heightmap" PATHSEP,
+	"orderlist" PATHSEP,
 	"gm" PATHSEP,
 	"data" PATHSEP,
 	"baseset" PATHSEP,
@@ -1094,7 +1095,7 @@ void DeterminePaths(const char *exe, bool only_local_path)
 	DEBUG(misc, 1, "%s found as personal directory", _personal_dir.c_str());
 
 	static const Subdirectory default_subdirs[] = {
-		SAVE_DIR, AUTOSAVE_DIR, SCENARIO_DIR, HEIGHTMAP_DIR, BASESET_DIR, NEWGRF_DIR, AI_DIR, AI_LIBRARY_DIR, GAME_DIR, GAME_LIBRARY_DIR, SCREENSHOT_DIR, SOCIAL_INTEGRATION_DIR
+		SAVE_DIR, AUTOSAVE_DIR, SCENARIO_DIR, HEIGHTMAP_DIR, ORDERLIST_DIR, BASESET_DIR, NEWGRF_DIR, AI_DIR, AI_LIBRARY_DIR, GAME_DIR, GAME_LIBRARY_DIR, SCREENSHOT_DIR, SOCIAL_INTEGRATION_DIR
 	};
 
 	for (uint i = 0; i < lengthof(default_subdirs); i++) {

--- a/src/fileio_type.h
+++ b/src/fileio_type.h
@@ -36,7 +36,7 @@ enum DetailedFileType {
 	DFT_HEIGHTMAP_PNG, ///< PNG file.
 
 	/* Orderlist files */
-	DFT_ORDERLIST, ///< XML file.
+	DFT_ORDERLIST, ///< JSON file.
 
 	/* fios 'files' */
 	DFT_FIOS_DRIVE,  ///< A drive (letter) entry.
@@ -116,6 +116,7 @@ enum Subdirectory {
 	AUTOSAVE_DIR,  ///< Subdirectory of save for autosaves
 	SCENARIO_DIR,  ///< Base directory for all scenarios
 	HEIGHTMAP_DIR, ///< Subdirectory of scenario for heightmaps
+	ORDERLIST_DIR, ///< Subdirectort for all orderlists
 	OLD_GM_DIR,    ///< Old subdirectory for the music
 	OLD_DATA_DIR,  ///< Old subdirectory for the data.
 	BASESET_DIR,   ///< Subdirectory for all base data (base sets, intro game)

--- a/src/fileio_type.h
+++ b/src/fileio_type.h
@@ -18,6 +18,7 @@ enum AbstractFileType {
 	FT_SAVEGAME,  ///< old or new savegame
 	FT_SCENARIO,  ///< old or new scenario
 	FT_HEIGHTMAP, ///< heightmap file
+	FT_ORDERLIST, ///< orderlist file
 
 	FT_INVALID = 7, ///< Invalid or unknown file type.
 	FT_NUMBITS = 3, ///< Number of bits required for storing a #AbstractFileType value.
@@ -33,6 +34,9 @@ enum DetailedFileType {
 	/* Heightmap files. */
 	DFT_HEIGHTMAP_BMP, ///< BMP file.
 	DFT_HEIGHTMAP_PNG, ///< PNG file.
+
+	/* Orderlist files */
+	DFT_ORDERLIST, ///< XML file.
 
 	/* fios 'files' */
 	DFT_FIOS_DRIVE,  ///< A drive (letter) entry.
@@ -76,6 +80,7 @@ enum FiosType {
 	FIOS_TYPE_OLD_SCENARIO = MAKE_FIOS_TYPE(FT_SCENARIO, DFT_OLD_GAME_FILE),
 	FIOS_TYPE_PNG          = MAKE_FIOS_TYPE(FT_HEIGHTMAP, DFT_HEIGHTMAP_PNG),
 	FIOS_TYPE_BMP          = MAKE_FIOS_TYPE(FT_HEIGHTMAP, DFT_HEIGHTMAP_BMP),
+	FIOS_TYPE_ORDERLIST    = MAKE_FIOS_TYPE(FT_ORDERLIST, DFT_ORDERLIST),
 
 	FIOS_TYPE_INVALID = MAKE_FIOS_TYPE(FT_INVALID, DFT_INVALID),
 };

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -33,9 +33,6 @@
 
 #include "safeguards.h"
 
-/*For some reason I need to pre-declare this function specifically, otherwise the whole thing just won't compile*/
-void FiosGetOrderlistList(SaveLoadOperation fop, bool show_dirs, FileList &file_list);
-
 /* Variables to display file lists */
 static std::string *_fios_path = nullptr;
 SortingBits _savegame_sort_order = SORT_BY_DATE | SORT_DESCENDING;

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -229,6 +229,11 @@ static std::string FiosMakeFilename(const std::string *path, const char *name, c
  * @param last Last element of buffer \a buf.
  * @return The completed filename.
  */
+
+std::string FiosMakeOrderListName(const char *name)
+{
+	return FiosMakeFilename(_fios_path, name, ".json");
+}
 std::string FiosMakeSavegameName(const char *name)
 {
 	const char *extension = (_game_mode == GM_EDITOR) ? ".scn" : ".sav";

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -259,9 +259,23 @@ std::string FiosMakeHeightmapName(const char *name)
  * @param name Filename to delete.
  * @return Whether the file deletion was successful.
  */
-bool FiosDelete(const char *name)
+bool FiosDelete(const char *name,AbstractFileType ft)
 {
-	std::string filename = FiosMakeSavegameName(name);
+	std::string filename;
+
+	switch (ft) {
+		case FT_SAVEGAME:
+		case FT_SCENARIO:
+			filename = FiosMakeSavegameName(name);
+			break;
+		case FT_ORDERLIST:
+			filename = FiosMakeOrderListName(name);
+			break;
+		default:
+			NOT_REACHED();
+			break;
+	}
+	
 	return unlink(filename.c_str()) == 0;
 }
 
@@ -530,7 +544,7 @@ FiosType FiosGetOrderlistListCallback(SaveLoadOperation fop, const std::string &
 	if (ext == nullptr) ext = "";
 
 	if (StrEqualsIgnoreCase(ext, ".json")) {
-		GetFileTitle(file, title, last, SAVE_DIR);
+		GetFileTitle(file, title, last, ORDERLIST_DIR);
 		return FIOS_TYPE_ORDERLIST;
 	}
 
@@ -548,7 +562,7 @@ void FiosGetOrderlistList(SaveLoadOperation fop, bool show_dirs, FileList &file_
 {
 	static std::optional<std::string> fios_save_path;
 
-	if (!fios_save_path) fios_save_path = FioFindDirectory(SAVE_DIR);
+	if (!fios_save_path) fios_save_path = FioFindDirectory(ORDERLIST_DIR);
 
 	_fios_path = &(*fios_save_path);
 

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -518,13 +518,13 @@ void FiosGetSavegameList(SaveLoadOperation fop, bool show_dirs, FileList &file_l
 FiosType FiosGetOrderlistListCallback(SaveLoadOperation fop, const std::string &file, const char *ext, char *title, const char *last)
 {
 	/* Show orderlist files
-	 * .XML orderlist files
+	 * .json orderlist files
 	 */
 
 	/* Don't crash if we supply no extension */
 	if (ext == nullptr) ext = "";
 
-	if (StrEqualsIgnoreCase(ext, ".xml")) {
+	if (StrEqualsIgnoreCase(ext, ".json")) {
 		GetFileTitle(file, title, last, SAVE_DIR);
 		return FIOS_TYPE_ORDERLIST;
 	}

--- a/src/fios.h
+++ b/src/fios.h
@@ -15,6 +15,7 @@
 #include "newgrf_config.h"
 #include "network/core/tcp_content_type.h"
 #include <vector>
+#include <order_type.h>
 
 
 /** Special values for save-load window for the data parameter of #InvalidateWindowData. */
@@ -51,7 +52,7 @@ DECLARE_ENUM_AS_BIT_SET(SortingBits)
 /* Variables to display file lists */
 extern SortingBits _savegame_sort_order;
 
-void ShowSaveLoadDialog(AbstractFileType abstract_filetype, SaveLoadOperation fop);
+void ShowSaveLoadDialog(AbstractFileType abstract_filetype, SaveLoadOperation fop,const Vehicle * veh = nullptr);
 
 void FiosGetSavegameList(SaveLoadOperation fop, bool show_dirs, FileList &file_list);
 void FiosGetScenarioList(SaveLoadOperation fop, bool show_dirs, FileList &file_list);
@@ -65,6 +66,8 @@ std::optional<uint64_t> FiosGetDiskFreeSpace(const std::string &path);
 bool FiosDelete(const char *name);
 std::string FiosMakeHeightmapName(const char *name);
 std::string FiosMakeSavegameName(const char *name);
+std::string FiosMakeOrderListName(const char *name);
+
 
 FiosType FiosGetSavegameListCallback(SaveLoadOperation fop, const std::string &file, const char *ext, char *title, const char *last);
 FiosType FiosGetScenarioListCallback(SaveLoadOperation fop, const std::string &file, const char *ext, char *title, const char *last);

--- a/src/fios.h
+++ b/src/fios.h
@@ -63,7 +63,7 @@ bool FiosBrowseTo(const FiosItem *item);
 
 std::string FiosGetCurrentPath();
 std::optional<uint64_t> FiosGetDiskFreeSpace(const std::string &path);
-bool FiosDelete(const char *name);
+bool FiosDelete(const char *name, AbstractFileType file_type);
 std::string FiosMakeHeightmapName(const char *name);
 std::string FiosMakeSavegameName(const char *name);
 std::string FiosMakeOrderListName(const char *name);

--- a/src/fios.h
+++ b/src/fios.h
@@ -56,6 +56,7 @@ void ShowSaveLoadDialog(AbstractFileType abstract_filetype, SaveLoadOperation fo
 void FiosGetSavegameList(SaveLoadOperation fop, bool show_dirs, FileList &file_list);
 void FiosGetScenarioList(SaveLoadOperation fop, bool show_dirs, FileList &file_list);
 void FiosGetHeightmapList(SaveLoadOperation fop, bool show_dirs, FileList &file_list);
+void FiosGetOrderlistList(SaveLoadOperation fop, bool show_dirs, FileList &file_list);
 
 bool FiosBrowseTo(const FiosItem *item);
 
@@ -68,6 +69,7 @@ std::string FiosMakeSavegameName(const char *name);
 FiosType FiosGetSavegameListCallback(SaveLoadOperation fop, const std::string &file, const char *ext, char *title, const char *last);
 FiosType FiosGetScenarioListCallback(SaveLoadOperation fop, const std::string &file, const char *ext, char *title, const char *last);
 FiosType FiosGetHeightmapListCallback(SaveLoadOperation fop, const std::string &file, const char *ext, char *title, const char *last);
+FiosType FiosGetOrderlistListCallback(SaveLoadOperation fop, const std::string &file, const char *ext, char *title, const char *last);
 
 void ScanScenarios();
 const char *FindScenario(const ContentInfo *ci, bool md5sum);

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -793,10 +793,10 @@ public:
 
 						auto type = GetDetailedFileType(file->type);
 
-						switch (type) {
-							case DFT_GAME_FILE: SaveOrLoad(file->name, SLO_CHECK, DFT_GAME_FILE, NO_DIRECTORY, false); break;
-							case DFT_ORDERLIST: break;
-							default: break;
+						if(GetDetailedFileType(file->type) == DFT_GAME_FILE) {
+
+							SaveOrLoad(file->name, SLO_CHECK, DFT_GAME_FILE, NO_DIRECTORY, false);
+							
 						}
 
 						this->InvalidateData(SLIWD_SELECTION_CHANGES);

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -234,6 +234,99 @@ static constexpr NWidgetPart _nested_save_dialog_widgets[] = {
 	EndContainer(),
 };
 
+/** Save Orderlist */
+static constexpr NWidgetPart _nested_save_orderlist_dialog_widgets[] = {
+	NWidget(NWID_HORIZONTAL),
+		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
+		NWidget(WWT_CAPTION, COLOUR_GREY, WID_SL_CAPTION),
+		NWidget(WWT_DEFSIZEBOX, COLOUR_GREY),
+	EndContainer(),
+	/* Current directory and free space */
+	NWidget(WWT_PANEL, COLOUR_GREY, WID_SL_BACKGROUND), SetFill(1, 0), SetResize(1, 0), EndContainer(),
+	NWidget(NWID_HORIZONTAL, NC_EQUALSIZE),
+		/* Left side : filter box and available files */
+		NWidget(NWID_VERTICAL),
+			/* Filter box with label */
+			NWidget(WWT_PANEL, COLOUR_GREY), SetFill(1, 1), SetResize(1, 1),
+				NWidget(NWID_HORIZONTAL), SetPadding(WidgetDimensions::unscaled.framerect.top, 0, WidgetDimensions::unscaled.framerect.bottom, 0),
+					SetPIP(WidgetDimensions::unscaled.frametext.left, WidgetDimensions::unscaled.frametext.right, 0),
+					NWidget(WWT_TEXT, COLOUR_GREY), SetFill(0, 1), SetDataTip(STR_SAVELOAD_FILTER_TITLE , STR_NULL),
+					NWidget(WWT_EDITBOX, COLOUR_GREY, WID_SL_FILTER), SetFill(1, 0), SetMinimalSize(50, 12), SetResize(1, 0),
+						SetDataTip(STR_LIST_FILTER_OSKTITLE, STR_LIST_FILTER_TOOLTIP),
+				EndContainer(),
+			EndContainer(),
+			/* Sort buttons */
+			NWidget(NWID_HORIZONTAL),
+				NWidget(NWID_HORIZONTAL, NC_EQUALSIZE),
+					NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SL_SORT_BYNAME), SetDataTip(STR_SORT_BY_CAPTION_NAME, STR_TOOLTIP_SORT_ORDER), SetFill(1, 0), SetResize(1, 0),
+					NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SL_SORT_BYDATE), SetDataTip(STR_SORT_BY_CAPTION_DATE, STR_TOOLTIP_SORT_ORDER), SetFill(1, 0), SetResize(1, 0),
+				EndContainer(),
+				NWidget(WWT_PUSHIMGBTN, COLOUR_GREY, WID_SL_HOME_BUTTON), SetMinimalSize(12, 12), SetDataTip(SPR_HOUSE_ICON, STR_SAVELOAD_HOME_BUTTON),
+			EndContainer(),
+			/* Files */
+			NWidget(NWID_HORIZONTAL),
+				NWidget(WWT_PANEL, COLOUR_GREY, WID_SL_FILE_BACKGROUND),
+					NWidget(WWT_INSET, COLOUR_GREY, WID_SL_DRIVES_DIRECTORIES_LIST), SetPadding(2, 2, 2, 2),
+							SetDataTip(0x0, STR_SAVELOAD_LIST_TOOLTIP), SetResize(1, 10), SetScrollbar(WID_SL_SCROLLBAR), EndContainer(),
+				EndContainer(),
+				NWidget(NWID_VSCROLLBAR, COLOUR_GREY, WID_SL_SCROLLBAR),
+			EndContainer(),
+			NWidget(WWT_PANEL, COLOUR_GREY),
+				NWidget(WWT_EDITBOX, COLOUR_GREY, WID_SL_SAVE_OSK_TITLE), SetPadding(2, 2, 2, 2), SetFill(1, 0), SetResize(1, 0),
+						SetDataTip(STR_SAVELOAD_OSKTITLE, STR_SAVELOAD_EDITBOX_TOOLTIP),
+			EndContainer(),
+			/* Save/delete buttons */
+			NWidget(NWID_HORIZONTAL),
+				NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SL_DELETE_SELECTION), SetDataTip(STR_SAVELOAD_DELETE_BUTTON, STR_SAVELOAD_DELETE_TOOLTIP), SetFill(1, 0), SetResize(1, 0),
+				NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SL_SAVE_GAME),        SetDataTip(STR_SAVELOAD_SAVE_BUTTON, STR_SAVELOAD_SAVE_TOOLTIP),     SetFill(1, 0), SetResize(1, 0),
+			EndContainer(),
+		EndContainer(),
+	EndContainer(),
+};
+
+/** Load Orderlist */
+static constexpr NWidgetPart _nested_load_orderlist_dialog_widgets[] = {
+	NWidget(NWID_HORIZONTAL),
+		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
+		NWidget(WWT_CAPTION, COLOUR_GREY, WID_SL_CAPTION),
+		NWidget(WWT_DEFSIZEBOX, COLOUR_GREY),
+	EndContainer(),
+	/* Current directory and free space */
+	NWidget(WWT_PANEL, COLOUR_GREY, WID_SL_BACKGROUND), SetFill(1, 0), SetResize(1, 0), EndContainer(),
+
+	NWidget(NWID_HORIZONTAL, NC_EQUALSIZE),
+		/* Left side : filter box and available files */
+		NWidget(NWID_VERTICAL),
+			/* Filter box with label */
+			NWidget(WWT_PANEL, COLOUR_GREY), SetFill(1, 1), SetResize(1, 1),
+				NWidget(NWID_HORIZONTAL), SetPadding(WidgetDimensions::unscaled.framerect.top, 0, WidgetDimensions::unscaled.framerect.bottom, 0),
+					SetPIP(WidgetDimensions::unscaled.frametext.left, WidgetDimensions::unscaled.frametext.right, 0),
+						NWidget(WWT_TEXT, COLOUR_GREY), SetFill(0, 1), SetDataTip(STR_SAVELOAD_FILTER_TITLE , STR_NULL),
+						NWidget(WWT_EDITBOX, COLOUR_GREY, WID_SL_FILTER), SetFill(1, 0), SetMinimalSize(50, 12), SetResize(1, 0),
+							SetDataTip(STR_LIST_FILTER_OSKTITLE, STR_LIST_FILTER_TOOLTIP),
+				EndContainer(),
+			EndContainer(),
+			/* Sort buttons */
+			NWidget(NWID_HORIZONTAL),
+				NWidget(NWID_HORIZONTAL, NC_EQUALSIZE),
+					NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SL_SORT_BYNAME), SetDataTip(STR_SORT_BY_CAPTION_NAME, STR_TOOLTIP_SORT_ORDER), SetFill(1, 0), SetResize(1, 0),
+					NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SL_SORT_BYDATE), SetDataTip(STR_SORT_BY_CAPTION_DATE, STR_TOOLTIP_SORT_ORDER), SetFill(1, 0), SetResize(1, 0),
+				EndContainer(),
+				NWidget(WWT_PUSHIMGBTN, COLOUR_GREY, WID_SL_HOME_BUTTON), SetMinimalSize(12, 12), SetDataTip(SPR_HOUSE_ICON, STR_SAVELOAD_HOME_BUTTON),
+			EndContainer(),
+			/* Files */
+			NWidget(NWID_HORIZONTAL),
+				NWidget(WWT_PANEL, COLOUR_GREY, WID_SL_FILE_BACKGROUND),
+					NWidget(WWT_INSET, COLOUR_GREY, WID_SL_DRIVES_DIRECTORIES_LIST), SetFill(1, 1), SetPadding(2, 2, 2, 2),
+							SetDataTip(0x0, STR_SAVELOAD_LIST_TOOLTIP), SetResize(1, 10), SetScrollbar(WID_SL_SCROLLBAR), EndContainer(),
+				EndContainer(),
+				NWidget(NWID_VSCROLLBAR, COLOUR_GREY, WID_SL_SCROLLBAR),
+			EndContainer(),
+			NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SL_LOAD_BUTTON), SetDataTip(STR_SAVELOAD_LOAD_BUTTON, STR_SAVELOAD_LOAD_TOOLTIP), SetFill(1, 0), SetResize(1, 0),
+		EndContainer(),
+	EndContainer(),
+};
+
 /** Text colours of #DetailedFileType fios entries in the window. */
 static const TextColour _fios_colours[] = {
 	TC_LIGHT_BROWN,  // DFT_OLD_GAME_FILE
@@ -325,6 +418,7 @@ public:
 
 				case FT_SCENARIO:
 				case FT_HEIGHTMAP:
+				case FT_ORDERLIST:
 					this->filename_editbox.text.Assign("UNNAMED");
 					break;
 
@@ -353,6 +447,10 @@ public:
 
 			case FT_HEIGHTMAP:
 				caption_string = (this->fop == SLO_SAVE) ? STR_SAVELOAD_SAVE_HEIGHTMAP : STR_SAVELOAD_LOAD_HEIGHTMAP;
+				break;
+
+			case FT_ORDERLIST:
+				caption_string = (this->fop == SLO_SAVE) ? STR_SAVELOAD_SAVE_ORDERLIST : STR_SAVELOAD_LOAD_ORDERLIST;
 				break;
 
 			default:
@@ -672,6 +770,8 @@ public:
 				break;
 
 			case WID_SL_DRIVES_DIRECTORIES_LIST: { // Click the listbox
+				printf("test");
+
 				auto it = this->vscroll->GetScrolledItemFromWidget(this->display_list, pt.y, this, WID_SL_DRIVES_DIRECTORIES_LIST, WidgetDimensions::scaled.inset.top);
 				if (it == this->display_list.end()) return;
 
@@ -685,13 +785,18 @@ public:
 				}
 
 				if (click_count == 1) {
+
 					if (this->selected != file) {
+						
 						this->selected = file;
 						_load_check_data.Clear();
 
-						if (GetDetailedFileType(file->type) == DFT_GAME_FILE) {
-							/* Other detailed file types cannot be checked before. */
-							SaveOrLoad(file->name, SLO_CHECK, DFT_GAME_FILE, NO_DIRECTORY, false);
+						auto type = GetDetailedFileType(file->type);
+
+						switch (type) {
+							case DFT_GAME_FILE: SaveOrLoad(file->name, SLO_CHECK, DFT_GAME_FILE, NO_DIRECTORY, false); break;
+							case DFT_ORDERLIST: break;
+							default: break;
 						}
 
 						this->InvalidateData(SLIWD_SELECTION_CHANGES);
@@ -704,7 +809,7 @@ public:
 				} else if (!_load_check_data.HasErrors()) {
 					this->selected = file;
 					if (this->fop == SLO_LOAD) {
-						if (this->abstract_filetype == FT_SAVEGAME || this->abstract_filetype == FT_SCENARIO) {
+						if (this->abstract_filetype == FT_SAVEGAME || this->abstract_filetype == FT_SCENARIO || this->abstract_filetype == FT_ORDERLIST) {
 							this->OnClick(pt, WID_SL_LOAD_BUTTON, 1);
 						} else {
 							assert(this->abstract_filetype == FT_HEIGHTMAP);
@@ -911,9 +1016,8 @@ public:
 								!_load_check_data.HasNewGrfs() || _load_check_data.grf_compatibility == GLC_ALL_GOOD);
 						break;
 					}
-
-					default:
-						NOT_REACHED();
+					
+					default: break;
 				}
 				break;
 
@@ -948,12 +1052,28 @@ static WindowDesc _load_heightmap_dialog_desc(__FILE__, __LINE__,
 	std::begin(_nested_load_heightmap_dialog_widgets), std::end(_nested_load_heightmap_dialog_widgets)
 );
 
+/** Load orderlist*/
+static WindowDesc _load_orderlist_dialog_desc(__FILE__, __LINE__,
+	WDP_CENTER, "load_orderlist", 257, 320,
+	WC_SAVELOAD, WC_NONE,
+	0,
+	std::begin(_nested_load_orderlist_dialog_widgets), std::end(_nested_load_orderlist_dialog_widgets)
+);
+
 /** Save game/scenario */
 static WindowDesc _save_dialog_desc(__FILE__, __LINE__,
 	WDP_CENTER, "save_game", 500, 294,
 	WC_SAVELOAD, WC_NONE,
 	0,
 	std::begin(_nested_save_dialog_widgets), std::end(_nested_save_dialog_widgets)
+);
+
+/** Load orderlist*/
+static WindowDesc _save_orderlist_dialog_desc(__FILE__, __LINE__,
+	WDP_CENTER, "save_orderlist", 257, 320,
+	WC_SAVELOAD, WC_NONE,
+	0,
+	std::begin(_nested_save_orderlist_dialog_widgets), std::end(_nested_save_orderlist_dialog_widgets)
 );
 
 /**
@@ -966,7 +1086,15 @@ void ShowSaveLoadDialog(AbstractFileType abstract_filetype, SaveLoadOperation fo
 	CloseWindowById(WC_SAVELOAD, 0);
 
 	WindowDesc *sld;
-	if (fop == SLO_SAVE) {
+	if (abstract_filetype == FT_ORDERLIST){
+
+		if (fop == SLO_SAVE) {
+			sld = &_save_orderlist_dialog_desc;
+		} else if (fop == SLO_LOAD) {
+			sld = &_load_orderlist_dialog_desc;
+		}
+
+	} else if (fop == SLO_SAVE) {
 		sld = &_save_dialog_desc;
 	} else {
 		/* Dialogue for loading a file. */

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -275,11 +275,10 @@ static constexpr NWidgetPart _nested_save_orderlist_dialog_widgets[] = {
 				NWidget(WWT_EDITBOX, COLOUR_GREY, WID_SL_SAVE_OSK_TITLE), SetPadding(2, 2, 2, 2), SetFill(1, 0), SetResize(1, 0),
 						SetDataTip(STR_SAVELOAD_OSKTITLE, STR_SAVELOAD_EDITBOX_TOOLTIP),
 			EndContainer(),
-			/* Save/delete buttons */
-			NWidget(NWID_HORIZONTAL),
-				NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SL_DELETE_SELECTION), SetDataTip(STR_SAVELOAD_DELETE_BUTTON, STR_SAVELOAD_DELETE_TOOLTIP), SetFill(1, 0), SetResize(1, 0),
-				NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SL_SAVE_GAME),        SetDataTip(STR_SAVELOAD_SAVE_BUTTON, STR_SAVELOAD_SAVE_TOOLTIP),     SetFill(1, 0), SetResize(1, 0),
-			EndContainer(),
+
+			/* Save button*/
+			NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SL_SAVE_GAME),        SetDataTip(STR_SAVELOAD_SAVE_BUTTON, STR_SAVELOAD_SAVE_TOOLTIP),     SetFill(1, 0), SetResize(1, 0),
+
 		EndContainer(),
 	EndContainer(),
 };
@@ -465,9 +464,9 @@ public:
 		this->querystrings[WID_SL_FILTER] = &this->filter_editbox;
 		this->filter_editbox.cancel_button = QueryString::ACTION_CLEAR;
 
-		/* pause is only used in single-player, non-editor mode, non-menu mode. It
+		/* pause is only used in single-player, non-editor mode, non-menu mode, when not operationg on orderlists. It
 		 * will be unpaused in the WE_DESTROY event handler. */
-		if (_game_mode != GM_MENU && !_networking && _game_mode != GM_EDITOR) {
+		if (_game_mode != GM_MENU && !_networking && _game_mode != GM_EDITOR && this->abstract_filetype != FT_ORDERLIST) {
 			DoCommandP(0, PM_PAUSED_SAVELOAD, 1, CMD_PAUSE);
 		}
 		SetObjectToPlace(SPR_CURSOR_ZZZ, PAL_NONE, HT_NONE, WC_MAIN_WINDOW, 0);
@@ -747,6 +746,11 @@ public:
 				if (this->abstract_filetype == FT_HEIGHTMAP) {
 					this->Close();
 					ShowHeightmapLoad();
+				}else if (this->abstract_filetype == FT_ORDERLIST) {
+
+					this->Close();
+					FILE *dataFile = fopen(this->selected->name, "r");
+					
 				} else if (!_load_check_data.HasNewGrfs() || _load_check_data.grf_compatibility != GLC_NOT_FOUND || _settings_client.gui.UserIsAllowedToChangeNewGRFs()) {
 					_switch_mode = (_game_mode == GM_EDITOR) ? SM_LOAD_SCENARIO : SM_LOAD_GAME;
 					ClearErrorMessages();

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -281,7 +281,10 @@ static constexpr NWidgetPart _nested_save_orderlist_dialog_widgets[] = {
 			EndContainer(),
 
 			/* Save button*/
-			NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SL_SAVE_GAME),        SetDataTip(STR_SAVELOAD_SAVE_BUTTON, STR_SAVELOAD_SAVE_TOOLTIP),     SetFill(1, 0), SetResize(1, 0),
+			NWidget(NWID_HORIZONTAL),
+				NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SL_DELETE_SELECTION), SetDataTip(STR_SAVELOAD_DELETE_BUTTON, STR_SAVELOAD_DELETE_TOOLTIP), SetFill(1, 0), SetResize(1, 0),
+				NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SL_SAVE_GAME),        SetDataTip(STR_SAVELOAD_SAVE_BUTTON, STR_SAVELOAD_SAVE_TOOLTIP),     SetFill(1, 0), SetResize(1, 0),
+			EndContainer(),
 
 		EndContainer(),
 	EndContainer(),
@@ -495,6 +498,10 @@ public:
 
 			case FT_HEIGHTMAP:
 				o_dir.name = FioFindDirectory(HEIGHTMAP_DIR);
+				break;
+
+			case FT_ORDERLIST:
+				o_dir.name = FioFindDirectory(ORDERLIST_DIR);
 				break;
 
 			default:
@@ -909,7 +916,7 @@ public:
 		if (this->fop != SLO_SAVE) return;
 
 		if (this->IsWidgetLowered(WID_SL_DELETE_SELECTION)) { // Delete button clicked
-			if (!FiosDelete(this->filename_editbox.text.buf)) {
+			if (!FiosDelete(this->filename_editbox.text.buf, this->abstract_filetype)) {
 				ShowErrorMessage(STR_ERROR_UNABLE_TO_DELETE_FILE, INVALID_STRING_ID, WL_ERROR);
 			} else {
 				this->InvalidateData(SLIWD_RESCAN_FILES);

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -5856,3 +5856,8 @@ STR_PLANE                                                       :{BLACK}{PLANE}
 STR_SHIP                                                        :{BLACK}{SHIP}
 
 STR_TOOLBAR_RAILTYPE_VELOCITY                                   :{STRING} ({VELOCITY})
+
+#json messages
+
+STR_ERROR_ORDERLIST_MALFORMED_JSON								:{WHITE}Input JSON was malformed
+STR_ERROR_JON													:{WHITE}JSON error

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3257,8 +3257,10 @@ STR_SAVELOAD_SAVE_CAPTION                                       :{WHITE}Save Gam
 STR_SAVELOAD_LOAD_CAPTION                                       :{WHITE}Load Game
 STR_SAVELOAD_SAVE_SCENARIO                                      :{WHITE}Save Scenario
 STR_SAVELOAD_LOAD_SCENARIO                                      :{WHITE}Load Scenario
-STR_SAVELOAD_LOAD_HEIGHTMAP                                     :{WHITE}Load Heightmap
 STR_SAVELOAD_SAVE_HEIGHTMAP                                     :{WHITE}Save Heightmap
+STR_SAVELOAD_LOAD_HEIGHTMAP                                     :{WHITE}Load Heightmap
+STR_SAVELOAD_SAVE_ORDERLIST										:{WHITE}Save Orderlist
+STR_SAVELOAD_LOAD_ORDERLIST										:{WHITE}Load Orderlist
 STR_SAVELOAD_HOME_BUTTON                                        :{BLACK}Click here to jump to the current default save/load directory
 STR_SAVELOAD_BYTES_FREE                                         :{BLACK}{BYTES} free
 STR_SAVELOAD_LIST_TOOLTIP                                       :{BLACK}List of drives, directories and saved-game files

--- a/src/lang/extra/english.txt
+++ b/src/lang/extra/english.txt
@@ -1681,6 +1681,8 @@ STR_ORDER_REVERSE_ORDER_LIST                                    :Reverse order l
 STR_ORDER_APPEND_REVERSED_ORDER_LIST                            :Append reversed order list
 STR_ORDER_DUPLICATE_ORDER                                       :Duplicate order
 STR_ORDER_CHANGE_JUMP_TARGET                                    :Change jump target
+STR_ORDER_EXPORT_ORDER_LIST										:Copy order list to file
+STR_ORDER_IMPORT_ORDER_LIST										:Get order list from file
 
 STR_ORDER_TRY_ACQUIRE_SLOT_BUTTON                               :Try acquire slot
 STR_ORDER_RELEASE_SLOT_BUTTON                                   :Release slot

--- a/src/lang/extra/english.txt
+++ b/src/lang/extra/english.txt
@@ -1681,8 +1681,8 @@ STR_ORDER_REVERSE_ORDER_LIST                                    :Reverse order l
 STR_ORDER_APPEND_REVERSED_ORDER_LIST                            :Append reversed order list
 STR_ORDER_DUPLICATE_ORDER                                       :Duplicate order
 STR_ORDER_CHANGE_JUMP_TARGET                                    :Change jump target
-STR_ORDER_EXPORT_ORDER_LIST										:Copy order list to file
-STR_ORDER_IMPORT_ORDER_LIST										:Get order list from file
+STR_ORDER_EXPORT_ORDER_LIST										:Export orderlist
+STR_ORDER_IMPORT_ORDER_LIST										:Import orderlist
 
 STR_ORDER_TRY_ACQUIRE_SLOT_BUTTON                               :Try acquire slot
 STR_ORDER_RELEASE_SLOT_BUTTON                                   :Release slot

--- a/src/order_base.h
+++ b/src/order_base.h
@@ -234,7 +234,7 @@ public:
 	void MakeLabel(OrderLabelSubType subtype);
 
 	std::string ToJSONString() const;
-	static void FromJSONString(const Vehicle * vehicle,std::string jsonSTR);
+	static Order FromJSONString(std::string jsonSTR);
 
 	/**
 	 * Is this a 'goto' order with a real destination?

--- a/src/order_base.h
+++ b/src/order_base.h
@@ -233,6 +233,10 @@ public:
 	void MakeChangeCounter();
 	void MakeLabel(OrderLabelSubType subtype);
 
+	std::string ToJSONString() const;
+	static Order FromJSONString(std::string);
+
+
 	/**
 	 * Is this a 'goto' order with a real destination?
 	 * @return True if the type is either #OT_GOTO_WAYPOINT, #OT_GOTO_DEPOT or #OT_GOTO_STATION.
@@ -780,6 +784,7 @@ public:
 	inline std::vector<DispatchSlot> &GetScheduledDispatchMutable() { return this->scheduled_dispatch; }
 
 	void SetScheduledDispatch(std::vector<DispatchSlot> dispatch_list);
+
 	void AddScheduledDispatch(uint32_t offset);
 	void RemoveScheduledDispatch(uint32_t offset);
 	void AdjustScheduledDispatch(int32_t adjust);
@@ -855,6 +860,19 @@ public:
 	 * @return  scheduled dispatch last dispatch
 	 */
 	inline int32_t GetScheduledDispatchDelay() const { return this->scheduled_dispatch_max_delay; }
+
+	/**
+	 * Get the scheduled dispatch flags
+	 * @return flags
+	 */
+	inline int8_t GetScheduledDispatchFlags() const {return this->scheduled_dispatch_flags; }
+
+	/**
+	 * Set the scheduled disaptch flags
+	 * @param flags
+	 */
+	inline void SetScheduledDispatchFlags(int8_t flags) { this->scheduled_dispatch_flags = flags; }
+
 
 	inline void BorrowSchedule(DispatchSchedule &other)
 	{
@@ -958,6 +976,9 @@ public:
 	void InsertOrderAt(Order *new_order, int index);
 	void DeleteOrderAt(int index);
 	void MoveOrder(int from, int to);
+
+	std::string ToJSONString();
+	static OrderList FromJSONString(std::string);
 
 	/**
 	 * Is this a shared order list?

--- a/src/order_base.h
+++ b/src/order_base.h
@@ -886,12 +886,16 @@ public:
 
 	inline std::string &ScheduleName() { return this->name; }
 	inline const std::string &ScheduleName() const { return this->name; }
+
+	static DispatchSchedule FromJSONString(std::string jsonString);
+	std::string ToJSONString();
 };
 
 /**
  * Shared order list linking together the linked list of orders and the list
  *  of vehicles sharing this order list.
  */
+
 struct OrderList : OrderListPool::PoolItem<&_orderlist_pool> {
 private:
 	friend void AfterLoadVehicles(bool part_of_load); ///< For instantiating the shared vehicle chain

--- a/src/order_base.h
+++ b/src/order_base.h
@@ -234,8 +234,7 @@ public:
 	void MakeLabel(OrderLabelSubType subtype);
 
 	std::string ToJSONString() const;
-	static Order FromJSONString(std::string);
-
+	static void FromJSONString(const Vehicle * vehicle,std::string jsonSTR);
 
 	/**
 	 * Is this a 'goto' order with a real destination?
@@ -978,7 +977,7 @@ public:
 	void MoveOrder(int from, int to);
 
 	std::string ToJSONString();
-	static OrderList FromJSONString(std::string);
+	static void FromJSONString(const Vehicle* v,std::string str);
 
 	/**
 	 * Is this a shared order list?

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -3491,8 +3491,77 @@ public:
 				switch (index) {
 					case 0: this->OrderClick_ReverseOrderList(0); break;
 					case 1: this->OrderClick_ReverseOrderList(1); break;
-					case 2: ShowSaveLoadDialog(FT_ORDERLIST, SLO_SAVE); break;
-					case 3: ShowSaveLoadDialog(FT_ORDERLIST, SLO_LOAD); break;
+					case 2: this->vehicle->orders->ToJSONString(); break;
+					case 3: this->vehicle->orders->FromJSONString(R"(
+		{
+		  "head": {
+			"scheduled-dispatch": [
+			  {
+				"duration": 106560,
+				"flags": 0,
+				"max-delay": 0,
+				"name": "alfredo",
+				"slots": [
+				  {
+					"flags": 0,
+					"offset": 4514
+				  },
+				  {
+					"flags": 0,
+					"offset": 90280
+				  }
+				],
+				"start-tick": 16729920
+			  }
+			]
+		  },
+		  "orders": [
+			{
+			  "destination-id": 0,
+			  "max-speed": 65535,
+			  "packed-data": 578,
+			  "refit-cargo": 254,
+			  "travel-time": 0,
+			  "wait-time": 0
+			},
+			{
+			  "destination-id": 0,
+			  "max-speed": 65535,
+			  "packed-data": 578,
+			  "refit-cargo": 254,
+			  "travel-time": 0,
+			  "wait-time": 0
+			},
+			{
+			  "destination-id": 0,
+			  "max-speed": 65535,
+			  "packed-data": 578,
+			  "refit-cargo": 254,
+			  "travel-time": 0,
+			  "wait-time": 0
+			},
+			{
+			  "destination-id": 0,
+			  "max-speed": 65535,
+			  "packed-data": 578,
+			  "refit-cargo": 254,
+			  "travel-time": 0,
+			  "wait-time": 0
+			},
+			{
+			  "destination-id": 0,
+			  "max-speed": 65535,
+			  "packed-data": 578,
+			  "refit-cargo": 254,
+			  "travel-time": 0,
+			  "wait-time": 0
+			}
+		  ]
+		}
+	)"); break;
+
+					//case 2: ShowSaveLoadDialog(FT_ORDERLIST, SLO_SAVE); break;
+					//case 3: ShowSaveLoadDialog(FT_ORDERLIST, SLO_LOAD); break;
 					default: NOT_REACHED();
 				}
 				break;

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -1548,6 +1548,7 @@ private:
 	};
 
 	int selected_order;
+	VehicleID vehicle_id;
 	VehicleOrderID order_over;         ///< Order over which another order is dragged, \c INVALID_VEH_ORDER_ID if none.
 	OrderPlaceObjectState goto_type;
 	Scrollbar *vscroll;
@@ -3491,89 +3492,8 @@ public:
 				switch (index) {
 					case 0: this->OrderClick_ReverseOrderList(0); break;
 					case 1: this->OrderClick_ReverseOrderList(1); break;
-					case 2: this->vehicle->orders->ToJSONString(); break;
-					case 3: this->vehicle->orders->FromJSONString(this->vehicle, R"({
-  "head": {
-    "scheduled-dispatch": [
-      {
-        "duration": 106560,
-        "flags": 0,
-        "max-delay": 0,
-        "name": "alfredo",
-        "slots": [
-          {
-            "flags": 0,
-            "offset": 4514
-          },
-          {
-            "flags": 0,
-            "offset": 90280
-          }
-        ],
-        "start-tick": 16729920
-      }
-    ]
-  },
-  "orders": [
-    {
-      "destination-id": 2,
-      "destination-name": "Grateley Halt",
-      "max-speed": 65535,
-      "packed-data": 33554513,
-      "refit-cargo": 254,
-      "travel-time": 0,
-      "wait-time": 0
-    },
-    {
-      "destination-id": 3,
-      "destination-name": "Grateley Exchange",
-      "max-speed": 65535,
-      "packed-data": 50331729,
-      "refit-cargo": 254,
-      "travel-time": 0,
-      "wait-time": 0
-    },
-    {
-      "destination-id": 4,
-      "destination-name": "Grateley Annexe",
-      "max-speed": 65535,
-      "packed-data": 67108945,
-      "refit-cargo": 254,
-      "travel-time": 0,
-      "wait-time": 0
-    },
-    {
-      "destination-id": 3,
-      "destination-name": "Grateley Exchange",
-      "max-speed": 65535,
-      "packed-data": 50331729,
-      "refit-cargo": 254,
-      "travel-time": 0,
-      "wait-time": 0
-    },
-    {
-      "destination-id": 2,
-      "destination-name": "Grateley Halt",
-      "max-speed": 65535,
-      "packed-data": 33554513,
-      "refit-cargo": 254,
-      "travel-time": 0,
-      "wait-time": 0
-    },
-    {
-      "destination-id": 1,
-      "destination-name": "Grateley Transfer",
-      "max-speed": 65535,
-      "packed-data": 16777297,
-      "refit-cargo": 254,
-      "travel-time": 0,
-      "wait-time": 0
-    }
-  ]
-})"); break;
-
-					//case 2: ShowSaveLoadDialog(FT_ORDERLIST, SLO_SAVE); break;
-					//case 3: ShowSaveLoadDialog(FT_ORDERLIST, SLO_LOAD); break;
+					case 2: ShowSaveLoadDialog(FT_ORDERLIST, SLO_SAVE, this->GetVehicle()); break;
+					case 3: ShowSaveLoadDialog(FT_ORDERLIST, SLO_LOAD, this->GetVehicle()); break;
 					default: NOT_REACHED();
 				}
 				break;

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -35,6 +35,7 @@
 #include "tracerestrict.h"
 #include "scope.h"
 #include "core/backup_type.hpp"
+#include "fios.h"
 
 #include "widgets/order_widget.h"
 
@@ -3490,8 +3491,8 @@ public:
 				switch (index) {
 					case 0: this->OrderClick_ReverseOrderList(0); break;
 					case 1: this->OrderClick_ReverseOrderList(1); break;
-					case 2: /*TODO:Copy order list as Unified Order List Format*/break;
-					case 3: /*TODO:Pase order list as Unified Order List Format*/break;
+					case 2: ShowSaveLoadDialog(FT_ORDERLIST, SLO_SAVE); break;
+					case 3: ShowSaveLoadDialog(FT_ORDERLIST, SLO_LOAD); break;
 					default: NOT_REACHED();
 				}
 				break;

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -1631,7 +1631,7 @@ private:
 
 	bool InsertNewOrder(uint64_t order_pack)
 	{
-		return DoCommandPEx(this->vehicle->tile, this->vehicle->index, this->OrderGetSel(), order_pack, CMD_INSERT_ORDER | CMD_MSG(STR_ERROR_CAN_T_INSERT_NEW_ORDER), nullptr, nullptr, 0);
+		return DoCommandPEx(this->vehicle->tile, this->vehicle->index, 0, order_pack, CMD_INSERT_ORDER | CMD_MSG(STR_ERROR_CAN_T_INSERT_NEW_ORDER), nullptr, nullptr, 0);
 	}
 
 	bool ModifyOrder(VehicleOrderID sel_ord, uint32_t p2, bool error_msg = true, const char *text = nullptr)
@@ -3492,73 +3492,85 @@ public:
 					case 0: this->OrderClick_ReverseOrderList(0); break;
 					case 1: this->OrderClick_ReverseOrderList(1); break;
 					case 2: this->vehicle->orders->ToJSONString(); break;
-					case 3: this->vehicle->orders->FromJSONString(R"(
-		{
-		  "head": {
-			"scheduled-dispatch": [
-			  {
-				"duration": 106560,
-				"flags": 0,
-				"max-delay": 0,
-				"name": "alfredo",
-				"slots": [
-				  {
-					"flags": 0,
-					"offset": 4514
-				  },
-				  {
-					"flags": 0,
-					"offset": 90280
-				  }
-				],
-				"start-tick": 16729920
-			  }
-			]
-		  },
-		  "orders": [
-			{
-			  "destination-id": 0,
-			  "max-speed": 65535,
-			  "packed-data": 578,
-			  "refit-cargo": 254,
-			  "travel-time": 0,
-			  "wait-time": 0
-			},
-			{
-			  "destination-id": 0,
-			  "max-speed": 65535,
-			  "packed-data": 578,
-			  "refit-cargo": 254,
-			  "travel-time": 0,
-			  "wait-time": 0
-			},
-			{
-			  "destination-id": 0,
-			  "max-speed": 65535,
-			  "packed-data": 578,
-			  "refit-cargo": 254,
-			  "travel-time": 0,
-			  "wait-time": 0
-			},
-			{
-			  "destination-id": 0,
-			  "max-speed": 65535,
-			  "packed-data": 578,
-			  "refit-cargo": 254,
-			  "travel-time": 0,
-			  "wait-time": 0
-			},
-			{
-			  "destination-id": 0,
-			  "max-speed": 65535,
-			  "packed-data": 578,
-			  "refit-cargo": 254,
-			  "travel-time": 0,
-			  "wait-time": 0
-			}
-		  ]
-		}
-	)"); break;
+					case 3: this->vehicle->orders->FromJSONString(this->vehicle, R"({
+  "head": {
+    "scheduled-dispatch": [
+      {
+        "duration": 106560,
+        "flags": 0,
+        "max-delay": 0,
+        "name": "alfredo",
+        "slots": [
+          {
+            "flags": 0,
+            "offset": 4514
+          },
+          {
+            "flags": 0,
+            "offset": 90280
+          }
+        ],
+        "start-tick": 16729920
+      }
+    ]
+  },
+  "orders": [
+    {
+      "destination-id": 2,
+      "destination-name": "Grateley Halt",
+      "max-speed": 65535,
+      "packed-data": 33554513,
+      "refit-cargo": 254,
+      "travel-time": 0,
+      "wait-time": 0
+    },
+    {
+      "destination-id": 3,
+      "destination-name": "Grateley Exchange",
+      "max-speed": 65535,
+      "packed-data": 50331729,
+      "refit-cargo": 254,
+      "travel-time": 0,
+      "wait-time": 0
+    },
+    {
+      "destination-id": 4,
+      "destination-name": "Grateley Annexe",
+      "max-speed": 65535,
+      "packed-data": 67108945,
+      "refit-cargo": 254,
+      "travel-time": 0,
+      "wait-time": 0
+    },
+    {
+      "destination-id": 3,
+      "destination-name": "Grateley Exchange",
+      "max-speed": 65535,
+      "packed-data": 50331729,
+      "refit-cargo": 254,
+      "travel-time": 0,
+      "wait-time": 0
+    },
+    {
+      "destination-id": 2,
+      "destination-name": "Grateley Halt",
+      "max-speed": 65535,
+      "packed-data": 33554513,
+      "refit-cargo": 254,
+      "travel-time": 0,
+      "wait-time": 0
+    },
+    {
+      "destination-id": 1,
+      "destination-name": "Grateley Transfer",
+      "max-speed": 65535,
+      "packed-data": 16777297,
+      "refit-cargo": 254,
+      "travel-time": 0,
+      "wait-time": 0
+    }
+  ]
+})"); break;
 
 					//case 2: ShowSaveLoadDialog(FT_ORDERLIST, SLO_SAVE); break;
 					//case 3: ShowSaveLoadDialog(FT_ORDERLIST, SLO_LOAD); break;

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -633,6 +633,8 @@ enum OrderDropDownID {
 static const StringID _order_manage_list_dropdown[] = {
 	STR_ORDER_REVERSE_ORDER_LIST,
 	STR_ORDER_APPEND_REVERSED_ORDER_LIST,
+	STR_ORDER_EXPORT_ORDER_LIST,
+	STR_ORDER_IMPORT_ORDER_LIST,
 	INVALID_STRING_ID
 };
 
@@ -3488,6 +3490,8 @@ public:
 				switch (index) {
 					case 0: this->OrderClick_ReverseOrderList(0); break;
 					case 1: this->OrderClick_ReverseOrderList(1); break;
+					case 2: /*TODO:Copy order list as Unified Order List Format*/break;
+					case 3: /*TODO:Pase order list as Unified Order List Format*/break;
 					default: NOT_REACHED();
 				}
 				break;

--- a/src/script/api/script_types.hpp
+++ b/src/script/api/script_types.hpp
@@ -86,7 +86,7 @@
 
 /* Define all types here, so we don't have to include the whole _type.h maze */
 typedef uint BridgeType;             ///< Internal name, not of any use for you.
-typedef byte CargoID;                ///< The ID of a cargo.
+typedef uint8_t CargoID;                ///< The ID of a cargo.
 class CommandCost;                   ///< The cost of a command.
 typedef uint16_t EngineID;           ///< The ID of an engine.
 typedef uint16_t GoalID;             ///< The ID of a goal.


### PR DESCRIPTION
## Motivation / Problem

Long order lists on complex networks are hard to manage, some external tools have been created to help with scheduling but the game has no common data format through which order lists can be exchanged.

Furthermore, in multiplayer games especially, it is often quite beneficial to test a new vehicle's schedule or perform a complete rescheduling of all your services in single player or a in different save and then re-import it in the main save/mp game.

Lastly, this system can proove effective when adding a new service to already busy routes, as it allows users to stitch together different orderlists that will come pre-loaded with the correct travel times for each section.

## Description

This is a proof-of concept and this PR is created only as a way to discuss this feature.

Allows users to Import or Export their orderlists to a unified JSON format.

This allows for easier managment of large complicated order lists with their associated schedule dispatches and travel times  creates a common format to import/export oder lists to and from external programs.

## Limitations

**Current issues:**

* Incomplete GUI integration (current test orderlist is imported via a hardcoded json string)
* No omission for some default-value fields during export
* More output- fields need to be added to enanche readability
* Importing is only limited to data which can fit into an order's Pack()
* No separation between human-editable and pure data fields
* No version number output
* Virtually no error checking (this is a prototype)

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)

