### PR TITLE
Add: Acceleration/braking adjustment setting for realistic braking

### DIFF
--- a/src/ground_vehicle.cpp
+++ b/src/ground_vehicle.cpp
@@ -309,7 +309,13 @@ GroundVehicleAcceleration GroundVehicle<T, Type>::GetAcceleration()
 				ShowTrainTooHeavyAdviceMessage(this);
 			}
 
-			if (Train::From(this)->UsingRealisticBraking() && _settings_game.vehicle.limit_train_acceleration) {
+			bool using_realistic_braking = Train::From(this)->UsingRealisticBraking();
+
+			if (using_realistic_braking) {
+				accel = DivTowardsPositiveInf(accel * _settings_game.vehicle.train_acc_braking_percent, 100);
+			}
+
+			if (using_realistic_braking && _settings_game.vehicle.limit_train_acceleration) {
 				accel = std::min(accel, 250);
 			}
 		}

--- a/src/lang/extra/english.txt
+++ b/src/lang/extra/english.txt
@@ -195,6 +195,10 @@ STR_CONFIG_SETTING_REALISTIC_BRAKING_ASPECT_LIMITED_HELPTEXT    :In the realisti
 STR_CONFIG_SETTING_LIMIT_TRAIN_ACCELERATION                     :Limit train acceleration: {STRING2}
 STR_CONFIG_SETTING_LIMIT_TRAIN_ACCELERATION_HELPTEXT            :When using the realistic train braking model, also limit the maximum acceleration of trains. This is to prevent passengers from spilling their drinks due to some train types otherwise accelerating excessively quickly.
 
+STR_CONFIG_SETTING_TRAIN_ACC_BRAKING_PERCENT                    :Train acceleration/braking scale factor: {STRING2}
+STR_CONFIG_SETTING_TRAIN_ACC_BRAKING_PERCENT_HELPTEXT           :The percentage by which train acceleration and braking is adjusted.{}{}This setting can be used to alter the acceleration and braking of trains, without changing the maximum speed of trains.
+STR_CONFIG_SETTING_TRAIN_ACC_BRAKING_PERCENT_VALUE              :{COMMA}%
+
 STR_CONFIG_SETTING_TRACK_EDIT_IGNORE_REALISTIC_BRAKING          :Track editing ignores realistic braking: {STRING2}
 STR_CONFIG_SETTING_TRACK_EDIT_IGNORE_REALISTIC_BRAKING_HELPTEXT :Allow track editing to ignore the realistic train braking model. When enabled, restrictions on editing/removing the reservation of moving trains are not enforced. This may result in non-realistic train braking behaviour.
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -2452,6 +2452,7 @@ static SettingsContainer &GetSettingsTree()
 				physics->Add(new SettingEntry("vehicle.train_braking_model"));
 				physics->Add(new ConditionallyHiddenSettingEntry("vehicle.realistic_braking_aspect_limited", []() -> bool { return GetGameSettings().vehicle.train_braking_model != TBM_REALISTIC; }));
 				physics->Add(new ConditionallyHiddenSettingEntry("vehicle.limit_train_acceleration", []() -> bool { return GetGameSettings().vehicle.train_braking_model != TBM_REALISTIC; }));
+				physics->Add(new ConditionallyHiddenSettingEntry("vehicle.train_acc_braking_percent", []() -> bool { return GetGameSettings().vehicle.train_braking_model != TBM_REALISTIC; }));
 				physics->Add(new ConditionallyHiddenSettingEntry("vehicle.track_edit_ignores_realistic_braking", []() -> bool { return GetGameSettings().vehicle.train_braking_model != TBM_REALISTIC; }));
 				physics->Add(new SettingEntry("vehicle.train_slope_steepness"));
 				physics->Add(new SettingEntry("vehicle.wagon_speed_limits"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -694,6 +694,7 @@ struct VehicleSettings {
 	uint8_t  train_braking_model;              ///< braking model for trains
 	uint8_t  realistic_braking_aspect_limited; ///< realistic braking lookahead is aspect limited
 	bool     limit_train_acceleration;         ///< when using realistic braking, also limit train acceleration
+	uint8_t  train_acc_braking_percent;        ///< adjustment factor for acceleration and braking of trains
 	bool     track_edit_ignores_realistic_braking; ///< when using realistic braking, allow track editing operations to ignore realistic braking restrictions
 	uint8_t  roadveh_acceleration_model;       ///< realistic acceleration for road vehicles
 	uint8_t  train_slope_steepness;            ///< Steepness of hills for trains when using realistic acceleration

--- a/src/table/settings/game_settings.ini
+++ b/src/table/settings/game_settings.ini
@@ -328,6 +328,18 @@ strhelp  = STR_CONFIG_SETTING_TRACK_EDIT_IGNORE_REALISTIC_BRAKING_HELPTEXT
 cat      = SC_EXPERT
 
 [SDT_VAR]
+var      = vehicle.train_acc_braking_percent
+type     = SLE_UINT8
+flags    = SF_PATCH
+def      = 100
+min      = 5
+max      = 200
+str      = STR_CONFIG_SETTING_TRAIN_ACC_BRAKING_PERCENT
+strhelp  = STR_CONFIG_SETTING_TRAIN_ACC_BRAKING_PERCENT_HELPTEXT
+strval   = STR_CONFIG_SETTING_TRAIN_ACC_BRAKING_PERCENT_VALUE
+cat      = SC_EXPERT
+
+[SDT_VAR]
 var      = vehicle.roadveh_acceleration_model
 type     = SLE_UINT8
 from     = SLV_139

--- a/src/train.h
+++ b/src/train.h
@@ -93,7 +93,7 @@ void NormalizeTrainVehInDepot(const Train *u);
 
 inline int GetTrainRealisticBrakingTargetDecelerationLimit(int acceleration_type)
 {
-	return 120 + (acceleration_type * 48);
+	return _settings_game.vehicle.train_acc_braking_percent * (120 + (acceleration_type * 48)) / 100;
 }
 
 /** Flags for TrainCache::cached_tflags */


### PR DESCRIPTION
This doesn't affect the maximum speed, but does give a much smoother acceleration and deceleration. By default this has no effect, but I have quite liked a value of 25%, particularly in the steam age.
