### PR TITLE
Feature: Allow changing the rate of industry events

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1026,14 +1026,13 @@ void SetPriceBaseMultiplier(Price price, int factor)
  */
 void StartupIndustryDailyChanges(bool init_counter)
 {
-	uint map_size = MapLogX() + MapLogY();
 	/* After getting map size, it needs to be scaled appropriately and divided by 31,
 	 * which stands for the days in a month.
 	 * Using just 31 will make it so that a monthly reset (based on the real number of days of that month)
 	 * would not be needed.
 	 * Since it is based on "fractional parts", the leftover days will not make much of a difference
 	 * on the overall total number of changes performed */
-	_economy.industry_daily_increment = (1 << map_size) / 31;
+	_economy.industry_daily_increment = (MapSize() * _settings_game.economy.industry_event_rate) / (31 * 100);
 
 	if (init_counter) {
 		/* A new game or a savegame from an older version will require the counter to be initialized */

--- a/src/lang/extra/english.txt
+++ b/src/lang/extra/english.txt
@@ -766,6 +766,9 @@ STR_CONFIG_SETTING_PURCHASED_LAND_CLEAR_GROUND_HELPTEXT         :If enabled, pur
 STR_CONFIG_SETTING_SPAWN_PRIMARY_INDUSTRY_ONLY                  :Only generate primary industries: {STRING2}
 STR_CONFIG_SETTING_SPAWN_PRIMARY_INDUSTRY_ONLY_HELPTEXT         :If enabled, only primary industries are generated during game play and map generation.
 
+STR_CONFIG_SETTING_INDUSTRY_EVENT_RATE                          :Industry event rate: {STRING2}
+STR_CONFIG_SETTING_INDUSTRY_EVENT_RATE_HELPTEXT                 :Scale the rate of industry events per economic time period in wallclock timekeeping mode, or per month/year in calendar timekeeping mode. This includes industry production changes, opening and closing.
+
 STR_PURCHASE_LAND_PERMITTED_NO                                  :No
 STR_PURCHASE_LAND_PERMITTED_SINGLE                              :Yes, 1 tile at a time
 STR_PURCHASE_LAND_PERMITTED_AREA                                :Yes, large areas at a time

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -2052,6 +2052,11 @@ static void DayLengthChanged(int32_t new_value)
 	MarkWholeScreenDirty();
 }
 
+static void IndustryEventRateChanged(int32_t new_value)
+{
+	if (_game_mode != GM_MENU) StartupIndustryDailyChanges(false);
+}
+
 static void TownZoneModeChanged(int32_t new_value)
 {
 	InvalidateWindowClassesData(WC_GAME_OPTIONS);

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -2661,6 +2661,7 @@ static SettingsContainer &GetSettingsTree()
 				industries->Add(new SettingEntry("station.serve_neutral_industries"));
 				industries->Add(new SettingEntry("station.station_delivery_mode"));
 				industries->Add(new SettingEntry("economy.spawn_primary_industry_only"));
+				industries->Add(new SettingEntry("economy.industry_event_rate"));
 			}
 
 			SettingsPage *cdist = environment->Add(new SettingsPage(STR_CONFIG_SETTING_ENVIRONMENT_CARGODIST));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -793,6 +793,7 @@ struct EconomySettings {
 	bool     disable_inflation_newgrf_flag;  ///< Disable NewGRF inflation flag
 	CargoPaymentAlgorithm payment_algorithm; ///< Cargo payment algorithm
 	TickRateMode tick_rate;                  ///< Tick rate mode
+	uint8_t industry_event_rate;             ///< Rate of industry events
 };
 
 struct OldEconomySettings {

--- a/src/table/settings/economy_settings.ini
+++ b/src/table/settings/economy_settings.ini
@@ -252,6 +252,18 @@ def      = false
 str      = STR_CONFIG_SETTING_SPAWN_PRIMARY_INDUSTRY_ONLY
 strhelp  = STR_CONFIG_SETTING_SPAWN_PRIMARY_INDUSTRY_ONLY_HELPTEXT
 
+[SDT_VAR]
+var      = economy.industry_event_rate
+type     = SLE_UINT8
+flags    = SF_NEWGAME_ONLY
+def      = 100
+min      = 1
+max      = 250
+str      = STR_CONFIG_SETTING_INDUSTRY_EVENT_RATE
+strhelp  = STR_CONFIG_SETTING_INDUSTRY_EVENT_RATE_HELPTEXT
+strval   = STR_CONFIG_SETTING_PERCENTAGE
+cat      = SC_EXPERT
+
 [SDT_BOOL]
 var      = economy.bribe
 def      = true

--- a/src/table/settings/economy_settings.ini
+++ b/src/table/settings/economy_settings.ini
@@ -13,6 +13,7 @@ static void ChangeTimekeepingUnits(int32_t new_value);
 static void ChangeMinutesPerYear(int32_t new_value);
 static void InvalidateCompanyWindow(int32_t new_value);
 static void DayLengthChanged(int32_t new_value);
+static void IndustryEventRateChanged(int32_t new_value);
 static bool CheckSharingRail(int32_t &new_value);
 static void SharingRailChanged(int32_t new_value);
 static bool CheckSharingRoad(int32_t &new_value);
@@ -255,7 +256,6 @@ strhelp  = STR_CONFIG_SETTING_SPAWN_PRIMARY_INDUSTRY_ONLY_HELPTEXT
 [SDT_VAR]
 var      = economy.industry_event_rate
 type     = SLE_UINT8
-flags    = SF_NEWGAME_ONLY
 def      = 100
 min      = 1
 max      = 250
@@ -263,6 +263,7 @@ str      = STR_CONFIG_SETTING_INDUSTRY_EVENT_RATE
 strhelp  = STR_CONFIG_SETTING_INDUSTRY_EVENT_RATE_HELPTEXT
 strval   = STR_CONFIG_SETTING_PERCENTAGE
 cat      = SC_EXPERT
+post_cb  = IndustryEventRateChanged
 
 [SDT_BOOL]
 var      = economy.bribe


### PR DESCRIPTION
## Motivation / Problem

I find that when playing on larger maps, the rate of random industry production changes, such as openings/closings and production rate changes happen entirely far too fast, as these events are scaled by map size. Some newgrf's allow disabling new industries spawning altogether, however I do not desire this, as I still want to allow some industries to spawn however at a greatly reduced rate

## Description

This feature changes the calculation used in StartupIndustryDailyChanges in economy.cpp based on conversations had with both JGR and Gwyd on 31/7/2024, first eliminating some clunky old calculations that relied on binary shifts of the total of the log2's of the map edge widths. The new calculation just directly uses the map area for the calculation, multiplied by a percentage which defaults to 100% in this feature.

## Limitations

Blanket assumptions that a setting change of 50% for instance should result in exactly 50% the amount of events, or newly created industries, will result in disappointment. Quite a bit of other stuff happens further down the chain with economy/industry events, but slowing down this rate to begin with does slow down the total number of events, which in turn does slow down industry creation as well as other events.

I haven't touched save/load.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
