### PR TITLE
Change: use spaces instead of `hsep` in timetable GUI

### DIFF
--- a/src/lang/extra/english.txt
+++ b/src/lang/extra/english.txt
@@ -1874,8 +1874,8 @@ STR_TIMETABLE_FILL_TIMETABLE_SUGGESTION_2                       :{BLACK}(Alterna
 
 STR_TIMETABLE_WARNINGS_OMITTED                                  :{BLACK}{NUM} further warnings omitted...
 
-STR_TIMETABLE_ARRIVAL_ABBREVIATION                              :A:
-STR_TIMETABLE_DEPARTURE_ABBREVIATION                            :D:
+STR_TIMETABLE_ARRIVAL_ABBREVIATION                              :A:{SPACE}{SPACE}
+STR_TIMETABLE_DEPARTURE_ABBREVIATION                            :D:{SPACE}{SPACE}
 
 STR_DATE_MINUTES_MINUTE_TOOLTIP                                 :{BLACK}Select minute
 STR_DATE_MINUTES_HOUR_TOOLTIP                                   :{BLACK}Select hour

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -437,7 +437,7 @@ struct TimetableWindow : GeneralVehicleWindow {
 				}
 				this->deparr_time_width = GetStringBoundingBox(STR_JUST_TT_TIME).width + 4;
 				this->deparr_abbr_width = std::max(GetStringBoundingBox(STR_TIMETABLE_ARRIVAL_ABBREVIATION).width, GetStringBoundingBox(STR_TIMETABLE_DEPARTURE_ABBREVIATION).width);
-				size.width = this->deparr_abbr_width + WidgetDimensions::scaled.hsep_wide + this->deparr_time_width + padding.width;
+				size.width = this->deparr_abbr_width + this->deparr_time_width + padding.width;
 				[[fallthrough]];
 
 			case WID_VT_ARRIVAL_DEPARTURE_SELECTION:


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->

The time bar in the timetable window uses an `hsep_wide` to seperate the arrival/departure abbreviations and the time. This does not work well with languages that use the ideographic colon, or the fullwidth colon, as the gap is now super wide.

|zh_CN (fullwidth colon)|zh_TW (fullwidth colon)|en (halfwidth colon)|
|---|---|---|
|![image](https://github.com/user-attachments/assets/f4227926-3d25-454f-8de8-e0120063bd4b)|![image](https://github.com/user-attachments/assets/e582296e-88eb-44d3-b419-d7d3101568f4)|![image](https://github.com/user-attachments/assets/5a19a6c8-0592-4c45-9a4f-b0f1df61a9cc)|

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->

Remove the `hsep` and add two `{SPACE}` after the abbreviation. It seems like that these strings are only used in the timetables window.

|zh_TW (fullwidth colon)|en (halfwidth colon + 2x `{SPACE}`)|
|---|---|
|![image](https://github.com/user-attachments/assets/6dba98a9-ddf4-4692-90a9-ed2a92546a85)|![image](https://github.com/user-attachments/assets/89f33a31-cec0-48ae-aac7-22f8a9b25b2a)|

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->

- I didn't change other language's translation.
- Might break text alignment??

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* **This PR touches english.txt or translations? Check the [guidelines]**(https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
