### PR TITLE
Fix slot creation from programmable signals window

### DIFF
--- a/src/programmable_signals_gui.cpp
+++ b/src/programmable_signals_gui.cpp
@@ -537,10 +537,10 @@ public:
 				case QSM_NEW_SLOT:
 				case QSM_NEW_COUNTER: {
 					using Payload = CmdPayload<CMD_PROGPRESIG_MODIFY_INSTRUCTION>;
-					ProgPresigModifyCommandType mode = (this->query_submode == QSM_NEW_SLOT) ? PPMCT_SLOT : PPMCT_COUNTER;
+					ProgPresigModifyCommandType mode = (qsm == QSM_NEW_SLOT) ? PPMCT_SLOT : PPMCT_COUNTER;
 					Payload follow_up_payload = Payload::Make(this->track, si->Id(), mode, {}, {});
 					TraceRestrictFollowUpCmdData follow_up{ BaseCommandContainer<CMD_PROGPRESIG_MODIFY_INSTRUCTION>((StringID)0, this->tile, std::move(follow_up_payload)) };
-					if (this->query_submode == QSM_NEW_SLOT) {
+					if (qsm == QSM_NEW_SLOT) {
 						TraceRestrictCreateSlotCmdData data;
 						data.vehtype = VEH_TRAIN;
 						data.parent = INVALID_TRACE_RESTRICT_SLOT_GROUP;
@@ -553,6 +553,7 @@ public:
 						data.follow_up_cmd = std::move(follow_up);
 						DoCommandP<CMD_CREATE_TRACERESTRICT_COUNTER>(data, STR_TRACE_RESTRICT_ERROR_COUNTER_CAN_T_CREATE, CommandCallback::CreateTraceRestrictCounter);
 					}
+					break;
 				}
 			}
 		}


### PR DESCRIPTION
## Motivation / Problem

1. Place a programmable signal.

2. Ctrl+Click it.

3. Insert a "condition".

4. Choose the "slot occupancy" condition type.

5. Choose the "Create a slot" option.

That gives an error message "Can't create counter... That field is not valid for the condition".

## Description

Since 42be0b8e0c58c26ba3ff80b0675a3f835aab66e3 query_submode is always QSM_NONE at this point, so the `if (this->query_submode == QSM_NEW_SLOT)` always took the else branch. So, fix the places that read query_submode after it's been overwritten.

The `break;` doesn't make a difference but I threw it in. (I added it locally because I was trying to patch slot creation to also prompt for the new slot's capacity, so I added a switch case for the result of the capacity prompt.)

## Limitations

None that I'm aware of.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
