### PR TITLE
vehicle list: Say "period" in wallclock mode

### DIFF
--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2046,7 +2046,7 @@ void BaseVehicleListWindow::DrawVehicleListItems(VehicleID selected_vehicle, int
 		if (this->grouping == GB_NONE) {
 			const Vehicle *v = vehgroup.GetSingleVehicle();
 
-			SetDParam(0, STR_VEHICLE_LIST_PROFIT_THIS_YEAR_LAST_YEAR);
+			SetDParam(0, EconTime::UsingWallclockUnits() ? STR_VEHICLE_LIST_PROFIT_THIS_PERIOD_LAST_PERIOD : STR_VEHICLE_LIST_PROFIT_THIS_YEAR_LAST_YEAR);
 			SetDParam(1, v->GetDisplayProfitThisYear());
 			SetDParam(2, v->GetDisplayProfitLastYear());
 
@@ -2167,7 +2167,7 @@ void BaseVehicleListWindow::DrawVehicleListItems(VehicleID selected_vehicle, int
 			}
 		} else {
 			StringID str = STR_JUST_STRING2;
-			SetDParam(0, STR_VEHICLE_LIST_PROFIT_THIS_YEAR_LAST_YEAR);
+			SetDParam(0, EconTime::UsingWallclockUnits() ? STR_VEHICLE_LIST_PROFIT_THIS_PERIOD_LAST_PERIOD : STR_VEHICLE_LIST_PROFIT_THIS_YEAR_LAST_YEAR);
 			SetDParam(1, vehgroup.GetDisplayProfitThisYear());
 			SetDParam(2, vehgroup.GetDisplayProfitLastYear());
 


### PR DESCRIPTION
## Motivation / Problem

The vehicle list should say "profit last period" in wallclock mode, but it actually says "profit last year".

In fact, STR_VEHICLE_LIST_PROFIT_THIS_PERIOD_LAST_PERIOD isn't used anywhere in JGRPP (it is used in OpenTTD, see https://github.com/OpenTTD/OpenTTD/blob/eca826b0a4d0334a1ddcd4237a7c2ef1724d6787/src/vehicle_gui.cpp#L1781).


## Description

Use the correct string.


## Limitations

It's weird that the string exists in english.txt, but the C++ files don't use it at all. I'm not sure how this happened.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
