### PR TITLE
Add appending serialized order lists

### DIFF
--- a/src/fios.h
+++ b/src/fios.h
@@ -14,6 +14,7 @@
 #include "company_base.h"
 #include "newgrf_config.h"
 #include "network/core/tcp_content_type.h"
+#include "order_type.h"
 #include <vector>
 
 
@@ -51,7 +52,7 @@ DECLARE_ENUM_AS_BIT_SET(SortingBits)
 /* Variables to display file lists */
 extern SortingBits _savegame_sort_order;
 
-void ShowSaveLoadDialog(AbstractFileType abstract_filetype, SaveLoadOperation fop, const Vehicle *veh = nullptr);
+void ShowSaveLoadDialog(AbstractFileType abstract_filetype, SaveLoadOperation fop, const Vehicle *veh = nullptr, VehicleOrderID order_insert_index = INVALID_VEH_ORDER_ID);
 
 void FiosGetSavegameList(SaveLoadOperation fop, bool show_dirs, FileList &file_list);
 void FiosGetScenarioList(SaveLoadOperation fop, bool show_dirs, FileList &file_list);

--- a/src/fios.h
+++ b/src/fios.h
@@ -52,7 +52,16 @@ DECLARE_ENUM_AS_BIT_SET(SortingBits)
 /* Variables to display file lists */
 extern SortingBits _savegame_sort_order;
 
-void ShowSaveLoadDialog(AbstractFileType abstract_filetype, SaveLoadOperation fop, const Vehicle *veh = nullptr, VehicleOrderID order_insert_index = INVALID_VEH_ORDER_ID);
+struct FiosOrderListInfo {
+	const Vehicle * const veh;
+	const VehicleOrderID order_insert_index;
+	const bool reverse;
+
+	FiosOrderListInfo(const Vehicle *veh, VehicleOrderID order_insert_index = INVALID_VEH_ORDER_ID, bool reverse = false)
+			: veh(veh), order_insert_index(order_insert_index), reverse(reverse) {}
+};
+
+void ShowSaveLoadDialog(AbstractFileType abstract_filetype, SaveLoadOperation fop, std::optional<FiosOrderListInfo> order_list_info = std::nullopt);
 
 void FiosGetSavegameList(SaveLoadOperation fop, bool show_dirs, FileList &file_list);
 void FiosGetScenarioList(SaveLoadOperation fop, bool show_dirs, FileList &file_list);

--- a/src/lang/extra/english.txt
+++ b/src/lang/extra/english.txt
@@ -1783,7 +1783,9 @@ STR_ORDER_APPEND_REVERSED_ORDER_LIST                            :Append reversed
 STR_ORDER_DUPLICATE_ORDER                                       :Duplicate order
 STR_ORDER_CHANGE_JUMP_TARGET                                    :Change jump target
 STR_ORDER_EXPORT_ORDER_LIST                                     :Export order list
-STR_ORDER_IMPORT_ORDER_LIST                                     :Import order list
+STR_ORDER_IMPORT_ORDER_LIST_REPLACE                             :Import order list (replace)
+STR_ORDER_IMPORT_ORDER_LIST_APPEND                              :Import order list (append)
+STR_ORDER_IMPORT_ORDER_LIST_INSERT                              :Import order list (insert)
 
 STR_ORDER_TRY_ACQUIRE_SLOT_BUTTON                               :Try acquire slot
 STR_ORDER_RELEASE_SLOT_BUTTON                                   :Release slot

--- a/src/lang/extra/english.txt
+++ b/src/lang/extra/english.txt
@@ -1786,6 +1786,8 @@ STR_ORDER_EXPORT_ORDER_LIST                                     :Export order li
 STR_ORDER_IMPORT_ORDER_LIST_REPLACE                             :Import order list (replace)
 STR_ORDER_IMPORT_ORDER_LIST_APPEND                              :Import order list (append)
 STR_ORDER_IMPORT_ORDER_LIST_INSERT                              :Import order list (insert)
+STR_ORDER_IMPORT_ORDER_LIST_APPEND_REVERSED                     :Import order list (append reversed)
+STR_ORDER_IMPORT_ORDER_LIST_INSERT_REVERSED                     :Import order list (insert reversed)
 
 STR_ORDER_TRY_ACQUIRE_SLOT_BUTTON                               :Try acquire slot
 STR_ORDER_RELEASE_SLOT_BUTTON                                   :Release slot

--- a/src/lang/extra/galician.txt
+++ b/src/lang/extra/galician.txt
@@ -1729,7 +1729,6 @@ STR_ORDER_APPEND_REVERSED_ORDER_LIST                            :Engadir lista d
 STR_ORDER_DUPLICATE_ORDER                                       :Duplicar orde
 STR_ORDER_CHANGE_JUMP_TARGET                                    :Modificar obxectivo de salto
 STR_ORDER_EXPORT_ORDER_LIST                                     :Exportar lista de ordes
-STR_ORDER_IMPORT_ORDER_LIST                                     :Importar lista de ordes
 
 STR_ORDER_TRY_ACQUIRE_SLOT_BUTTON                               :Tentar adquirir slot
 STR_ORDER_RELEASE_SLOT_BUTTON                                   :Liberar slot

--- a/src/lang/extra/korean.txt
+++ b/src/lang/extra/korean.txt
@@ -1729,7 +1729,6 @@ STR_ORDER_APPEND_REVERSED_ORDER_LIST                            :반전된 경�
 STR_ORDER_DUPLICATE_ORDER                                       :경로 복제
 STR_ORDER_CHANGE_JUMP_TARGET                                    :건너뛰기 번호 변경
 STR_ORDER_EXPORT_ORDER_LIST                                     :경로 목록 내보내기
-STR_ORDER_IMPORT_ORDER_LIST                                     :경로 목록 가져오기
 
 STR_ORDER_TRY_ACQUIRE_SLOT_BUTTON                               :슬롯 획득 시도
 STR_ORDER_RELEASE_SLOT_BUTTON                                   :슬롯 해제

--- a/src/lang/extra/simplified_chinese.txt
+++ b/src/lang/extra/simplified_chinese.txt
@@ -1725,7 +1725,6 @@ STR_ORDER_APPEND_REVERSED_ORDER_LIST                            :将反转调度
 STR_ORDER_DUPLICATE_ORDER                                       :复制命令
 STR_ORDER_CHANGE_JUMP_TARGET                                    :改变跳转目标
 STR_ORDER_EXPORT_ORDER_LIST                                     :导出调度计划
-STR_ORDER_IMPORT_ORDER_LIST                                     :导入调度计划
 
 STR_ORDER_TRY_ACQUIRE_SLOT_BUTTON                               :尝试领取路签
 STR_ORDER_RELEASE_SLOT_BUTTON                                   :返还路签

--- a/src/order_bulk.h
+++ b/src/order_bulk.h
@@ -25,6 +25,7 @@ enum class BulkOrderOp {
 	InsertFail,
 	SeekTo,
 	Move,
+	AdjustTravelAfterReverse,
 	SetRouteOverlayColour,
 	ClearSchedules,
 	AppendSchedule,
@@ -105,6 +106,12 @@ public:
 	{
 		this->OpCode(BulkOrderOp::Move);
 		this->serialiser.Send_generic_seq(from, to, count);
+	}
+
+	void AdjustTravelAfterReverse(VehicleOrderID start, uint16_t count)
+	{
+		this->OpCode(BulkOrderOp::AdjustTravelAfterReverse);
+		this->serialiser.Send_generic_seq(start, count);
 	}
 
 	void SetRouteOverlayColour(Colours colour)

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -621,7 +621,8 @@ static const StringID _order_manage_list_dropdown[] = {
 	STR_ORDER_REVERSE_ORDER_LIST,
 	STR_ORDER_APPEND_REVERSED_ORDER_LIST,
 	STR_ORDER_EXPORT_ORDER_LIST,
-	STR_ORDER_IMPORT_ORDER_LIST,
+	STR_ORDER_IMPORT_ORDER_LIST_REPLACE,
+	STR_ORDER_IMPORT_ORDER_LIST_APPEND
 };
 
 /** Variables for conditional orders; this defines the order of appearance in the dropdown box */
@@ -2963,7 +2964,8 @@ public:
 
 				DropDownList list;
 				list.push_back(MakeDropDownListStringItem(STR_ORDER_DUPLICATE_ORDER, 0, false));
-				if (order->IsType(OT_CONDITIONAL)) list.push_back(MakeDropDownListStringItem(STR_ORDER_CHANGE_JUMP_TARGET, 1, false));
+				list.push_back(MakeDropDownListStringItem(STR_ORDER_IMPORT_ORDER_LIST_INSERT, 1, false));
+				if (order->IsType(OT_CONDITIONAL)) list.push_back(MakeDropDownListStringItem(STR_ORDER_CHANGE_JUMP_TARGET, 2, false));
 
 				if (this->vehicle->type == VEH_TRAIN && order->IsType(OT_GOTO_STATION) && (order->GetNonStopType() & ONSF_NO_STOP_AT_DESTINATION_STATION) == 0) {
 					const OrderStopLocation osl = order->GetStopLocation();
@@ -3691,6 +3693,7 @@ public:
 					case 1: this->OrderClick_ReverseOrderList(ReverseOrderOperation::AppendReversed); break;
 					case 2: ShowSaveLoadDialog(FT_ORDERLIST, SLO_SAVE, this->GetVehicle()); break;
 					case 3: ShowSaveLoadDialog(FT_ORDERLIST, SLO_LOAD, this->GetVehicle()); break;
+					case 4: ShowSaveLoadDialog(FT_ORDERLIST, SLO_LOAD, this->GetVehicle(), this->GetVehicle()->GetNumOrders()); break;
 					default: NOT_REACHED();
 				}
 				break;
@@ -3718,6 +3721,10 @@ public:
 						break;
 
 					case 1:
+						ShowSaveLoadDialog(FT_ORDERLIST, SLO_LOAD, this->GetVehicle(), this->OrderGetSel());
+						break;
+
+					case 2:
 						this->OrderClick_Goto(OPOS_CONDITIONAL_RETARGET);
 						break;
 

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -622,7 +622,8 @@ static const StringID _order_manage_list_dropdown[] = {
 	STR_ORDER_APPEND_REVERSED_ORDER_LIST,
 	STR_ORDER_EXPORT_ORDER_LIST,
 	STR_ORDER_IMPORT_ORDER_LIST_REPLACE,
-	STR_ORDER_IMPORT_ORDER_LIST_APPEND
+	STR_ORDER_IMPORT_ORDER_LIST_APPEND,
+	STR_ORDER_IMPORT_ORDER_LIST_APPEND_REVERSED
 };
 
 /** Variables for conditional orders; this defines the order of appearance in the dropdown box */
@@ -2964,8 +2965,7 @@ public:
 
 				DropDownList list;
 				list.push_back(MakeDropDownListStringItem(STR_ORDER_DUPLICATE_ORDER, 0, false));
-				list.push_back(MakeDropDownListStringItem(STR_ORDER_IMPORT_ORDER_LIST_INSERT, 1, false));
-				if (order->IsType(OT_CONDITIONAL)) list.push_back(MakeDropDownListStringItem(STR_ORDER_CHANGE_JUMP_TARGET, 2, false));
+				if (order->IsType(OT_CONDITIONAL)) list.push_back(MakeDropDownListStringItem(STR_ORDER_CHANGE_JUMP_TARGET, 1, false));
 
 				if (this->vehicle->type == VEH_TRAIN && order->IsType(OT_GOTO_STATION) && (order->GetNonStopType() & ONSF_NO_STOP_AT_DESTINATION_STATION) == 0) {
 					const OrderStopLocation osl = order->GetStopLocation();
@@ -3013,6 +3013,11 @@ public:
 					add_colour(COLOUR_ORANGE);
 					add_colour(COLOUR_PINK);
 				}
+
+				list.push_back(MakeDropDownListDividerItem());
+				list.push_back(MakeDropDownListStringItem(STR_ORDER_IMPORT_ORDER_LIST_INSERT, 0x400, false));
+				list.push_back(MakeDropDownListStringItem(STR_ORDER_IMPORT_ORDER_LIST_INSERT_REVERSED, 0x401, false));
+
 				ShowDropDownList(this, std::move(list), -1, widget, 0, DDMF_NONE, DDSF_SHARED);
 				break;
 			}
@@ -3691,9 +3696,10 @@ public:
 				switch (index) {
 					case 0: this->OrderClick_ReverseOrderList(ReverseOrderOperation::Reverse); break;
 					case 1: this->OrderClick_ReverseOrderList(ReverseOrderOperation::AppendReversed); break;
-					case 2: ShowSaveLoadDialog(FT_ORDERLIST, SLO_SAVE, this->GetVehicle()); break;
-					case 3: ShowSaveLoadDialog(FT_ORDERLIST, SLO_LOAD, this->GetVehicle()); break;
-					case 4: ShowSaveLoadDialog(FT_ORDERLIST, SLO_LOAD, this->GetVehicle(), this->GetVehicle()->GetNumOrders()); break;
+					case 2: ShowSaveLoadDialog(FT_ORDERLIST, SLO_SAVE, FiosOrderListInfo(this->GetVehicle())); break;
+					case 3: ShowSaveLoadDialog(FT_ORDERLIST, SLO_LOAD, FiosOrderListInfo(this->GetVehicle())); break;
+					case 4: ShowSaveLoadDialog(FT_ORDERLIST, SLO_LOAD, FiosOrderListInfo(this->GetVehicle(), this->GetVehicle()->GetNumOrders())); break;
+					case 5: ShowSaveLoadDialog(FT_ORDERLIST, SLO_LOAD, FiosOrderListInfo(this->GetVehicle(), this->GetVehicle()->GetNumOrders(), true)); break;
 					default: NOT_REACHED();
 				}
 				break;
@@ -3721,11 +3727,15 @@ public:
 						break;
 
 					case 1:
-						ShowSaveLoadDialog(FT_ORDERLIST, SLO_LOAD, this->GetVehicle(), this->OrderGetSel());
+						this->OrderClick_Goto(OPOS_CONDITIONAL_RETARGET);
 						break;
 
-					case 2:
-						this->OrderClick_Goto(OPOS_CONDITIONAL_RETARGET);
+					case 0x400:
+						ShowSaveLoadDialog(FT_ORDERLIST, SLO_LOAD, FiosOrderListInfo(this->GetVehicle(), this->OrderGetSel()));
+						break;
+
+					case 0x401:
+						ShowSaveLoadDialog(FT_ORDERLIST, SLO_LOAD, FiosOrderListInfo(this->GetVehicle(), this->OrderGetSel(), true));
 						break;
 
 					default:

--- a/src/order_serialisation.cpp
+++ b/src/order_serialisation.cpp
@@ -224,7 +224,7 @@ static nlohmann::ordered_json OrderToJSON(const Order &o, VehicleType vt)
 	}
 
 	if (o.IsType(OT_GOTO_WAYPOINT)) {
-		if (o.GetWaypointFlags().Test(OrderWaypointFlag::Reverse)) json["waypoint-reverse"] = true;
+		if (o.GetWaypointFlags().Test(OrderWaypointFlag::Reverse)) json[OFName::WAYPOINT_REVERSE] = true;
 	}
 
 	if (o.IsSlotCounterOrder()) {

--- a/src/order_serialisation.cpp
+++ b/src/order_serialisation.cpp
@@ -150,10 +150,10 @@ static nlohmann::ordered_json OrderToJSON(const Order &o, VehicleType vt)
 		if (o.GetDepotActionType() & ODATFB_NEAREST_DEPOT) {
 			json[OFName::DEPOT_ID] = "nearest";
 		} else {
-			DepotID depo_id = o.GetDestination().ToDepotID();
-			json[OFName::DEPOT_ID] = depo_id.base();
-			if (Depot::GetIfValid(depo_id) != nullptr){
-				const Depot * d = Depot::GetIfValid(depo_id);
+			DepotID depot_id = o.GetDestination().ToDepotID();
+			json[OFName::DEPOT_ID] = depot_id.base();
+			if (Depot::GetIfValid(depot_id) != nullptr) {
+				const Depot * d = Depot::GetIfValid(depot_id);
 				if (!d->name.empty()) {
 					json[OFName::DESTINATION_NAME] = d->name;
 				} else {
@@ -476,7 +476,7 @@ std::string OrderListToJSONString(const OrderList *ol)
 	if (group != nullptr && !group->name.empty()) {
 		json[FName::VEHICLE_GROUP_NAME] = group->name;
 		json[FName::NESTED_VEHICLE_GROUP_NAMES] = nlohmann::json::array();
-		for (; group != nullptr; group = Group::GetIfValid(group->parent)){
+		for (; group != nullptr; group = Group::GetIfValid(group->parent)) {
 			json[FName::NESTED_VEHICLE_GROUP_NAMES] += group->name;
 		}
 	}

--- a/src/order_serialisation.cpp
+++ b/src/order_serialisation.cpp
@@ -1371,6 +1371,10 @@ OrderImportErrors ImportJsonOrderList(const Vehicle *veh, std::string_view json_
 		order_id++;
 	}
 
+	if (reverse_orders) {
+		cmd_buffer.op_serialiser.AdjustTravelAfterReverse(replace_existing_mode ? 0 : initial_order_count, INVALID_VEH_ORDER_ID);
+	}
+
 	if (!replace_existing_mode) {
 		cmd_buffer.op_serialiser.Move(initial_order_count, insert_index, INVALID_VEH_ORDER_ID);
 	}

--- a/src/order_serialisation.cpp
+++ b/src/order_serialisation.cpp
@@ -57,7 +57,7 @@ struct OrderSerialisationFieldNames {
 	struct Schedules {
 		static constexpr char OBJKEY[] = "schedules";
 
-		/** <array<int|object>, when item is an int the value rapresents the offset, when it's an object the offset can be found in the apropriate field */
+		/** <array<int|object>>, when item is an int the value rapresents the offset, when it's an object the offset can be found in the apropriate field */
 		struct Slots {
 			static constexpr char OBJKEY[]      = "slots";
 
@@ -81,7 +81,7 @@ struct OrderSerialisationFieldNames {
 		static constexpr char TYPE[]                        = "type";                        ///< enum    Required
 		static constexpr char DESTINATION_ID[]              = "destination-id";              ///< int     Unique in-game destination-id
 		static constexpr char DESTINATION_NAME[]            = "destination-name";            ///< string  Export-only
-		static constexpr char DESTINATION_LOCATION[]        = "destination-location";        ///< object  XY tile coordinate
+		static constexpr char DESTINATION_LOCATION[]        = "destination-location";        ///< object  Export-only XY tile coordinate
 		static constexpr char DEPOT_ID[]                    = "depot-id";                    ///< int|string  Unique in-game destination-id or "nearest"
 		static constexpr char DEPOT_ACTION[]                = "depot-action";                ///< enum
 		static constexpr char WAYPOINT_REVERSE[]            = "waypoint-reverse";            ///< bool
@@ -121,7 +121,7 @@ struct OrderSerialisationFieldNames {
 		static constexpr char CONDITION_VALUE2[]            = "condition-value2";            ///< int     Raw data
 		static constexpr char CONDITION_VALUE3[]            = "condition-value3";            ///< int     Raw data
 		static constexpr char CONDITION_VALUE4[]            = "condition-value4";            ///< int     Raw data
-		static constexpr char REFIT_CARGO[]                 = "refit-cargo";                 ///< int
+		static constexpr char REFIT_CARGO[]                 = "refit-cargo";                 ///< int     Cargo-id
 		static constexpr char SCHEDULE_INDEX[]              = "schedule-index";              ///< int
 	};
 };

--- a/src/order_serialisation.cpp
+++ b/src/order_serialisation.cpp
@@ -87,8 +87,10 @@ struct OrderSerialisationFieldNames {
 		static constexpr char WAYPOINT_REVERSE[]            = "waypoint-reverse";            ///< bool
 		static constexpr char COLOUR[]                      = "colour";                      ///< enum
 		static constexpr char TRAVEL_TIME[]                 = "travel-time";                 ///< int
+		static constexpr char TRAVEL_FIXED[]                = "travel-fixed";                ///< bool
 		static constexpr char MAX_SPEED[]                   = "max-speed";                   ///< int
 		static constexpr char WAIT_TIME[]                   = "wait-time";                   ///< int
+		static constexpr char WAIT_FIXED[]                  = "wait-fixed";                  ///< bool
 		static constexpr char STOPPING_PATTERN[]            = "stopping-pattern";            ///< enum
 		static constexpr char STOP_LOCATION[]               = "stop-location";               ///< enum
 		static constexpr char STOP_DIRECTION[]              = "stop-direction";              ///< enum
@@ -106,6 +108,7 @@ struct OrderSerialisationFieldNames {
 		static constexpr char COUNTER_VALUE[]               = "counter-value";               ///< int     Value to be applied to "counter-operation"
 		static constexpr char SLOT_ACTION[]                 = "slot-action";                 ///< int
 		static constexpr char JUMP_TAKEN_TRAVEL_TIME[]      = "jump-taken-travel-time";      ///< int
+		static constexpr char JUMP_TAKEN_TRAVEL_FIXED[]     = "jump-taken-travel-fixed";     ///< bool
 		static constexpr char CONDITION_VARIABLE[]          = "condition-variable";          ///< enum    Required when "order-type" is OT_CONDITIONAL
 		static constexpr char CONDITION_COMPARATOR[]        = "condition-comparator";        ///< enum
 		static constexpr char JUMP_TO[]                     = "jump-to";                     ///< string  Jump-label to jump to
@@ -166,6 +169,9 @@ static nlohmann::ordered_json OrderToJSON(const Order &o, VehicleType vt)
 	if (o.IsGotoOrder() || o.GetType() == OT_CONDITIONAL) {
 		if (o.IsTravelTimetabled()) {
 			json[OFName::TRAVEL_TIME] = o.GetTravelTime();
+			if (o.IsTravelFixed()) {
+				json[OFName::TRAVEL_FIXED] = true;
+			}
 		}
 
 		if (o.GetMaxSpeed() != UINT16_MAX) {
@@ -176,6 +182,9 @@ static nlohmann::ordered_json OrderToJSON(const Order &o, VehicleType vt)
 	if (o.IsGotoOrder()) {
 		if (o.IsWaitTimetabled()) {
 			json[OFName::WAIT_TIME] = o.GetWaitTime();
+			if (o.IsWaitFixed()) {
+				json[OFName::WAIT_FIXED] = true;
+			}
 		}
 
 		if (vt == VEH_ROAD || vt == VEH_TRAIN) {
@@ -256,6 +265,9 @@ static nlohmann::ordered_json OrderToJSON(const Order &o, VehicleType vt)
 	if (o.IsType(OT_CONDITIONAL)) {
 		if (o.IsWaitTimetabled()) {
 			json[OFName::JUMP_TAKEN_TRAVEL_TIME] = o.GetWaitTime();
+			if (o.IsWaitFixed()) {
+				json[OFName::JUMP_TAKEN_TRAVEL_TIME] = true;
+			}
 		}
 
 		json[OFName::CONDITION_VARIABLE] = o.GetConditionVariable();
@@ -936,9 +948,12 @@ static void ImportJsonOrder(JSONToVehicleCommandParser<JSONToVehicleMode::Order>
 
 	json_importer.TryApplyTimetableCommand(OFName::MAX_SPEED, MTF_TRAVEL_SPEED, JOIET_MINOR);
 	json_importer.TryApplyTimetableCommand(OFName::WAIT_TIME, MTF_WAIT_TIME, JOIET_MINOR);
+	json_importer.TryApplyTimetableCommand<bool>(OFName::WAIT_FIXED, MTF_SET_WAIT_FIXED, JOIET_MINOR);
 	json_importer.TryApplyTimetableCommand(OFName::TRAVEL_TIME, MTF_TRAVEL_TIME, JOIET_MINOR);
+	json_importer.TryApplyTimetableCommand<bool>(OFName::TRAVEL_FIXED, MTF_SET_TRAVEL_FIXED, JOIET_MINOR);
 	json_importer.TryApplyTimetableCommand<OrderLeaveType>(OFName::TIMETABLE_LEAVE_TYPE, MTF_SET_LEAVE_TYPE, JOIET_MINOR);
 	json_importer.TryApplyTimetableCommand(OFName::JUMP_TAKEN_TRAVEL_TIME, MTF_WAIT_TIME, JOIET_MINOR);
+	json_importer.TryApplyTimetableCommand<bool>(OFName::JUMP_TAKEN_TRAVEL_FIXED, MTF_SET_WAIT_FIXED, JOIET_MINOR);
 
 	json_importer.TryApplyModifyOrder<OrderStopLocation>(OFName::STOP_LOCATION, MOF_STOP_LOCATION, JOIET_MINOR, json_importer.import_settings.stop_location);
 	json_importer.TryApplyModifyOrder<DiagDirection>(OFName::STOP_DIRECTION, MOF_RV_TRAVEL_DIR, JOIET_MINOR);

--- a/src/order_serialisation.cpp
+++ b/src/order_serialisation.cpp
@@ -150,11 +150,11 @@ static nlohmann::ordered_json OrderToJSON(const Order &o, VehicleType vt)
 
 		if (o.GetDepotActionType() & ODATFB_SELL) {
 			json[OFName::DEPOT_ACTION] = DA_SELL;
-		} else if (o.GetDepotActionType() & ODATFB_UNBUNCH) {
-			json[OFName::DEPOT_ACTION] = DA_UNBUNCH;
 		} else if (o.GetDepotActionType() & ODATFB_HALT) {
 			json[OFName::DEPOT_ACTION] = DA_STOP;
-		} else if (o.GetDepotActionType() & ODATF_SERVICE_ONLY) {
+		} else if (o.GetDepotActionType() & ODATFB_UNBUNCH) {
+			json[OFName::DEPOT_ACTION] = DA_UNBUNCH;
+		} else if (o.GetDepotOrderType() & ODTFB_SERVICE) {
 			json[OFName::DEPOT_ACTION] = DA_SERVICE;
 		}
 	}

--- a/src/order_serialisation.cpp
+++ b/src/order_serialisation.cpp
@@ -41,11 +41,12 @@
 static constexpr uint8_t ORDERLIST_JSON_OUTPUT_VERSION = 1;
 
 struct OrderSerialisationFieldNames {
-	static constexpr char VERSION[]              = "version";              ///< int
-	static constexpr char SOURCE[]               = "source";               ///< string      OTTD version that generated the list
-	static constexpr char VEHICLE_TYPE[]         = "vehicle-type";         ///< enum
-	static constexpr char VEHICLE_GROUP_NAME[]   = "vehicle-group-name";   ///< string      Export-only, name of group of first vehicle in the orderlist
-	static constexpr char ROUTE_OVERLAY_COLOUR[] = "route-overlay-colour"; ///< enum
+	static constexpr char VERSION[]                    = "version";                    ///< int
+	static constexpr char SOURCE[]                     = "source";                     ///< string      OTTD version that generated the list
+	static constexpr char VEHICLE_TYPE[]               = "vehicle-type";               ///< enum
+	static constexpr char VEHICLE_GROUP_NAME[]         = "vehicle-group-name";         ///< string      Export-only, name of group of first vehicle in the orderlist
+	static constexpr char NESTED_VEHICLE_GROUP_NAMES[] = "nested-vehicle-group-names"; ///< array<str>  Exèprt-only, names of all of the first vehicle's groups (ascending)
+	static constexpr char ROUTE_OVERLAY_COLOUR[]       = "route-overlay-colour";       ///< enum
 
 	struct GameProperties {
 		static constexpr char OBJKEY[]                = "game-properties";
@@ -474,6 +475,10 @@ std::string OrderListToJSONString(const OrderList *ol)
 	json[FName::VEHICLE_TYPE] = vt;
 	if (group != nullptr && !group->name.empty()) {
 		json[FName::VEHICLE_GROUP_NAME] = group->name;
+		json[FName::NESTED_VEHICLE_GROUP_NAMES] = nlohmann::json::array();
+		for (; group != nullptr; group = Group::GetIfValid(group->parent)){
+			json[FName::NESTED_VEHICLE_GROUP_NAMES] += group->name;
+		}
 	}
 
 	if (ol->GetRouteOverlayColour() != COLOUR_WHITE) {

--- a/src/order_serialisation.cpp
+++ b/src/order_serialisation.cpp
@@ -94,7 +94,6 @@ struct OrderSerialisationFieldNames {
 		static constexpr char STOPPING_PATTERN[]            = "stopping-pattern";            ///< enum
 		static constexpr char STOP_LOCATION[]               = "stop-location";               ///< enum
 		static constexpr char STOP_DIRECTION[]              = "stop-direction";              ///< enum
-		static constexpr char WAYPOINT_ACTION[]             = "waypoint-action";
 		static constexpr char LOAD[]                        = "load";                        ///< enum
 		static constexpr char UNLOAD[]                      = "unload";                      ///< enum
 		static constexpr char LOAD_BY_CARGO_TYPE[]          = "load-by-cargo-type";          ///< object  Contains "load" and "unload" settings for specific cargo-ids

--- a/src/order_serialisation.h
+++ b/src/order_serialisation.h
@@ -38,7 +38,7 @@ struct OrderImportErrors {
 	bool HasErrors() const;
 };
 
-OrderImportErrors ImportJsonOrderList(const Vehicle *veh, std::string_view json_str);
+OrderImportErrors ImportJsonOrderList(const Vehicle *veh, std::string_view json_str, VehicleOrderID insert_index = INVALID_VEH_ORDER_ID, bool reverse_orders = false);
 std::string OrderListToJSONString(const OrderList *ol);
 
 Colours OrderErrorTypeToColour(JsonOrderImportErrorType error_type);

--- a/src/timetable_cmd.cpp
+++ b/src/timetable_cmd.cpp
@@ -1091,8 +1091,3 @@ void UpdateVehicleTimetable(Vehicle *v, bool travelling)
 
 	SetTimetableWindowsDirty(v);
 }
-
-void SetOrderFixedWaitTime(Vehicle *v, VehicleOrderID order_number, uint32_t wait_time, bool wait_timetabled, bool wait_fixed) {
-	ChangeTimetable(v, order_number, wait_time, MTF_WAIT_TIME, wait_timetabled, true);
-	ChangeTimetable(v, order_number, wait_fixed ? 1 : 0, MTF_SET_WAIT_FIXED, false, true);
-}


### PR DESCRIPTION
Allows importing serialized order lists without removing all previous orders.
Also has a to be tested implementation for reversing order lists at import.
Probably needs some UI rethinking.