### PR TITLE
Add setting for reliability decay speed

### DIFF
--- a/src/lang/extra/english.txt
+++ b/src/lang/extra/english.txt
@@ -219,6 +219,21 @@ STR_CONFIG_SETTING_IMPROVED_BREAKDOWNS                          :Enable improved
 STR_CONFIG_SETTING_MAX_RELIABILITY_FLOOR                        :Maximum reliability floor: {STRING2}
 STR_CONFIG_SETTING_MAX_RELIABILITY_FLOOR_HELPTEXT               :At vehicle introduction, a random maximum reliability is chosen between this value and 100%.{}{}Choose a high value if you want all vehicles to have high maximum reliability.{}Choose a low value to increase the effect of random chance (do this at your own risk).{}{}The maximum reliability is only reached after the introductory period, and declines again at the vehicle's end of life (as was always the case).{}{}In an existing game, resetengines may have to be called for a change to take effect.{}{}Old behavior: the value was chosen between 75% and 100%.
 
+STR_CONFIG_SETTING_RELIABILITY_SPEED                            :Reliability decay factor: {STRING2}
+STR_CONFIG_SETTING_RELIABILITY_SPEED_HELPTEXT                   :How fast a vehicle's reliability decreases.{}Higher values mean that reliability will decrease faster.
+###length 11
+STR_CONFIG_SETTING_DIVIDE_32                                    :x1/32
+STR_CONFIG_SETTING_DIVIDE_16                                    :x1/16
+STR_CONFIG_SETTING_DIVIDE_8                                     :x1/8
+STR_CONFIG_SETTING_DIVIDE_4                                     :x1/4
+STR_CONFIG_SETTING_DIVIDE_2                                     :x1/2
+STR_CONFIG_SETTING_TIMES_1                                      :x1
+STR_CONFIG_SETTING_TIMES_2                                      :x2
+STR_CONFIG_SETTING_TIMES_4                                      :x4
+STR_CONFIG_SETTING_TIMES_8                                      :x8
+STR_CONFIG_SETTING_TIMES_16                                     :x16
+STR_CONFIG_SETTING_TIMES_32                                     :x32
+
 STR_CONFIG_SETTING_SHIP_COLLISION_AVOIDANCE                     :Ships avoid collisions: {STRING2}
 STR_CONFIG_SETTING_SHIP_COLLISION_AVOIDANCE_HELPTEXT            :When enabled, ships try to avoid passing through each other. The best results are obtained when 90° turns are forbidden.
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -4345,6 +4345,10 @@ bool AfterLoadGame()
 		_settings_game.difficulty.max_reliability_floor = 75;
 	}
 
+	if (SlXvIsFeatureMissing(XSLFI_RELIABILITY_DECAY_SPEED)) {
+		_settings_game.difficulty.reliability_decay_speed = 0;
+	}
+
 	if (SlXvIsFeatureMissing(XSLFI_RAIL_DEPOT_SPEED_LIMIT)) {
 		_settings_game.vehicle.rail_depot_speed_limit = 61;
 	}

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -1127,6 +1127,7 @@ SettingsContainer &GetSettingsTree()
 			disasters->Add(new SettingEntry("vehicle.no_train_crash_other_company"));
 			disasters->Add(new SettingEntry("difficulty.vehicle_breakdowns"));
 			disasters->Add(new SettingEntry("difficulty.max_reliability_floor"));
+			disasters->Add(new SettingEntry("difficulty.reliability_decay_speed"));
 			disasters->Add(new SettingEntry("vehicle.improved_breakdowns"));
 			disasters->Add(new SettingEntry("vehicle.pay_for_repair"));
 			disasters->Add(new SettingEntry("vehicle.repair_cost"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -118,6 +118,7 @@ struct DifficultySettings {
 	uint8_t  competitor_speed;                      ///< the speed at which the AI builds
 	uint8_t  vehicle_breakdowns;                    ///< likelihood of vehicles breaking down
 	uint8_t  max_reliability_floor;                 ///< The minimum value (%) for maximum reliability randomizer
+	int8_t   reliability_decay_speed;               ///< reliability decay factor (higher means faster decay)
 	uint8_t  subsidy_multiplier;                    ///< payment multiplier for subsidized deliveries
 	uint16_t subsidy_duration;                      ///< duration of subsidies
 	uint8_t  construction_cost;                     ///< how expensive is building

--- a/src/sl/extended_ver_sl.cpp
+++ b/src/sl/extended_ver_sl.cpp
@@ -175,6 +175,7 @@ const std::initializer_list<SlxiSubChunkInfo> _sl_xv_sub_chunk_infos = {
 	{ XSLFI_ST_INDUSTRY_CARGO_MODE,           XSCF_IGNORABLE_UNKNOWN,   1,   1, "st_industry_cargo_mode",           nullptr, nullptr, nullptr          },
 	{ XSLFI_TL_SPEED_LIMIT,                   XSCF_IGNORABLE_UNKNOWN,   1,   1, "tl_speed_limit",                   nullptr, nullptr, nullptr          },
 	{ XSLFI_MAX_RELIABILITY_FLOOR,            XSCF_IGNORABLE_UNKNOWN,   1,   1, "max_reliability_floor",            nullptr, nullptr, nullptr          },
+	{ XSLFI_RELIABILITY_DECAY_SPEED,          XSCF_IGNORABLE_UNKNOWN,   1,   1, "reliability_decay_speed",          nullptr, nullptr, nullptr          },
 	{ XSLFI_RAIL_DEPOT_SPEED_LIMIT,           XSCF_IGNORABLE_UNKNOWN,   1,   1, "rail_depot_speed_limit",           nullptr, nullptr, nullptr          },
 	{ XSLFI_WAYPOINT_FLAGS,                   XSCF_NULL,                1,   1, "waypoint_flags",                   nullptr, nullptr, nullptr          },
 	{ XSLFI_ROAD_WAYPOINTS,                   XSCF_NULL,                1,   1, "road_waypoints",                   nullptr, nullptr, nullptr          },

--- a/src/sl/extended_ver_sl.h
+++ b/src/sl/extended_ver_sl.h
@@ -124,6 +124,7 @@ enum SlXvFeatureIndex {
 	XSLFI_ST_INDUSTRY_CARGO_MODE,                 ///< Station industry cargo mode setting
 	XSLFI_TL_SPEED_LIMIT,                         ///< Through load maximum speed setting
 	XSLFI_MAX_RELIABILITY_FLOOR,                  ///< The minimum value (%) for maximum reliability randomizer
+	XSLFI_RELIABILITY_DECAY_SPEED,                ///< Reliability decay factor (higher means faster decay)
 	XSLFI_RAIL_DEPOT_SPEED_LIMIT,                 ///< Rail depot maximum speed setting
 	XSLFI_WAYPOINT_FLAGS,                         ///< Waypoint flags
 	XSLFI_ROAD_WAYPOINTS,                         ///< Road waypoints

--- a/src/table/settings/game_settings.ini
+++ b/src/table/settings/game_settings.ini
@@ -629,6 +629,19 @@ strhelp  = STR_CONFIG_SETTING_MAX_RELIABILITY_FLOOR_HELPTEXT
 strval   = STR_CONFIG_SETTING_PERCENTAGE
 cat      = SC_EXPERT
 
+[SDT_VAR]
+var      = difficulty.reliability_decay_speed
+type     = SLE_INT8
+flags    = SettingFlag::Patch, SettingFlag::GuiDropdown
+def      = 0
+min      = -5
+max      = 5
+interval = 1
+str      = STR_CONFIG_SETTING_RELIABILITY_SPEED
+strhelp  = STR_CONFIG_SETTING_RELIABILITY_SPEED_HELPTEXT
+strval   = STR_CONFIG_SETTING_DIVIDE_32
+cat      = SC_EXPERT
+
 [SDT_BOOL]
 var      = vehicle.ship_collision_avoidance
 flags    = SettingFlag::Patch

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2312,7 +2312,8 @@ void CheckVehicleBreakdown(Vehicle *v)
 	/* decrease reliability */
 	if (!_settings_game.order.no_servicing_if_no_breakdowns ||
 			_settings_game.difficulty.vehicle_breakdowns != 0) {
-		v->reliability = rel = std::max((rel_old = v->reliability) - v->reliability_spd_dec, 0);
+		const int reliability_dec = (v->reliability_spd_dec << 5) >> (5 - _settings_game.difficulty.reliability_decay_speed);
+		v->reliability = rel = std::max((rel_old = v->reliability) - reliability_dec, 0);
 		if ((rel_old >> 8) != (rel >> 8)) SetWindowDirty(WC_VEHICLE_DETAILS, v->First()->index);
 	}
 


### PR DESCRIPTION
New setting (expert) under _Disasters / Accidents_ => _Reliability decay factor_, which speeds up or slows down reliability decay 2x, 4x, 16x or 32x

I tested it and the change works in a running game including on non-leading engines in multiheaded trains. It took me some figuring out to get that working (`TrainReliabilityDecayChanged`) and there's probably a neater way to do it.

I don't like that the calculation formula is in two places (`StartupOneEngine` and `TrainReliabilityDecayChanged`) but I'm not sure what better solution there is. Rerunning `StartupOneEngine` in latter function is not an option as that could alter vehicle introduction dates and maximum reliability.

If something (script, newgrf?) modifies `reliability_spd_dec` of a particular vehicle at some point, this setting change ignores that, but I don't know if that's something that happens.