### PR TITLE
Change: draw zoning in the scenario editor

### DIFF
--- a/src/zoning_cmd.cpp
+++ b/src/zoning_cmd.cpp
@@ -453,7 +453,7 @@ inline SpriteID TileZoningSpriteEvaluationCached(TileIndex tile, Owner owner, Zo
  */
 void DrawTileZoning(const TileInfo *ti)
 {
-	if (IsTileType(ti->tile, MP_VOID) || _game_mode != GM_NORMAL) {
+	if (IsTileType(ti->tile, MP_VOID) || (_game_mode != GM_NORMAL && _game_mode != GM_EDITOR)) {
 		return;
 	}
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

I was making a scenario and I wanted to place cities on the 3x3 town road grid. When I tried to view the grid, the zone outlines did not appear.


## Description

This MR allows the rest of `DrawTileZone` to be executed when in the scenario editor.

<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/d6d1ba94-2c65-4822-9210-9bd4bb03dd3e" />


## Limitations

No known limitations.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
