### PR TITLE
Add: "orders include station" signal programming condition

### DIFF
--- a/src/lang/extra/english.txt
+++ b/src/lang/extra/english.txt
@@ -882,6 +882,7 @@ STR_TRACE_RESTRICT_VARIABLE_MAX_SPEED                           :max speed
 STR_TRACE_RESTRICT_VARIABLE_CURRENT_ORDER                       :current order
 STR_TRACE_RESTRICT_VARIABLE_NEXT_ORDER                          :next order
 STR_TRACE_RESTRICT_VARIABLE_LAST_VISITED_STATION                :last visited station
+STR_TRACE_RESTRICT_VARIABLE_ORDERS_INCLUDE                      :orders include station
 STR_TRACE_RESTRICT_VARIABLE_CARGO                               :cargo
 STR_TRACE_RESTRICT_VARIABLE_LOAD_PERCENT                        :load percentage
 STR_TRACE_RESTRICT_VARIABLE_ENTRY_DIRECTION                     :entry direction

--- a/src/tracerestrict.cpp
+++ b/src/tracerestrict.cpp
@@ -454,6 +454,19 @@ void TraceRestrictProgram::Execute(const Train *v, const TraceRestrictProgramInp
 						result = TestStationCondition(v->last_station_visited, item);
 						break;
 
+					case TRIT_COND_ORDERS_INCLUDE: {
+						if (v->orders == nullptr) break;
+						if (v->orders->GetNumOrders() == 0) break;
+
+						for (const Order *order = v->orders->GetFirstOrder(); order != v->orders->GetLastOrder(); order = v->orders->GetNext(order)) {
+							result = TestOrderCondition(order, item);
+							if (result) {
+								break;
+							}
+						}
+						break;
+					}
+
 					case TRIT_COND_CARGO: {
 						bool have_cargo = false;
 						for (const Vehicle *v_iter = v; v_iter != nullptr; v_iter = v_iter->Next()) {
@@ -1267,6 +1280,7 @@ CommandCost TraceRestrictProgram::Validate(const std::span<const TraceRestrictPr
 				case TRIT_COND_CURRENT_ORDER:
 				case TRIT_COND_NEXT_ORDER:
 				case TRIT_COND_LAST_STATION:
+				case TRIT_COND_ORDERS_INCLUDE:
 					if (invalid_order_condition()) return unknown_instruction();
 					break;
 
@@ -1437,6 +1451,7 @@ CommandCost TraceRestrictProgram::Validate(const std::span<const TraceRestrictPr
 				case TRIT_COND_CURRENT_ORDER:
 				case TRIT_COND_NEXT_ORDER:
 				case TRIT_COND_LAST_STATION:
+				case TRIT_COND_ORDERS_INCLUDE:
 				case TRIT_COND_TARGET_DIRECTION:
 					actions_used_flags |= TRPAUF_ORDER_CONDITIONALS;
 					break;
@@ -2794,7 +2809,8 @@ void TraceRestrictRemoveDestinationID(TraceRestrictOrderCondAuxField type, Desti
 			TraceRestrictInstructionItemRef item = iter.InstructionRef(); // note this is a reference wrapper
 			if (item.GetType() == TRIT_COND_CURRENT_ORDER ||
 					item.GetType() == TRIT_COND_NEXT_ORDER ||
-					item.GetType() == TRIT_COND_LAST_STATION) {
+					item.GetType() == TRIT_COND_LAST_STATION ||
+					item.GetType() == TRIT_COND_ORDERS_INCLUDE) {
 				if (item.GetAuxField() == type && item.GetValue() == index.base()) {
 					SetTraceRestrictValueDefault(item, TRVT_ORDER); // this updates the instruction in-place
 				}

--- a/src/tracerestrict.h
+++ b/src/tracerestrict.h
@@ -190,6 +190,7 @@ enum TraceRestrictItemType : uint8_t {
 	TRIT_COND_TARGET_DIRECTION    = 31,   ///< Test direction of order target tile relative to this signal tile
 	TRIT_COND_RESERVATION_THROUGH = 32,   ///< Test if train reservation passes through tile
 	TRIT_COND_TRAIN_IN_SLOT_GROUP = 33,   ///< Test train slot membership
+	TRIT_COND_ORDERS_INCLUDE      = 34,   ///< Test train includes targer
 
 	TRIT_COND_END                 = 48,   ///< End (exclusive) of conditional item types, note that this has the same value as TRIT_REVERSE
 	TRIT_REVERSE                  = 48,   ///< Reverse behind/at signal
@@ -1093,6 +1094,7 @@ inline TraceRestrictTypePropertySet GetTraceRestrictTypeProperties(TraceRestrict
 			case TRIT_COND_CURRENT_ORDER:
 			case TRIT_COND_NEXT_ORDER:
 			case TRIT_COND_LAST_STATION:
+			case TRIT_COND_ORDERS_INCLUDE:
 				out.value_type = TRVT_ORDER;
 				out.cond_type = TRCOT_BINARY;
 				break;

--- a/src/tracerestrict_gui.cpp
+++ b/src/tracerestrict_gui.cpp
@@ -621,6 +621,7 @@ static std::span<const TraceRestrictDropDownListItem> GetConditionDropDownListIt
 		{ TRIT_COND_CURRENT_ORDER,                                    STR_TRACE_RESTRICT_VARIABLE_CURRENT_ORDER,             TRDDLIF_NONE },
 		{ TRIT_COND_NEXT_ORDER,                                       STR_TRACE_RESTRICT_VARIABLE_NEXT_ORDER,                TRDDLIF_NONE },
 		{ TRIT_COND_LAST_STATION,                                     STR_TRACE_RESTRICT_VARIABLE_LAST_VISITED_STATION,      TRDDLIF_NONE },
+		{ TRIT_COND_ORDERS_INCLUDE,                                   STR_TRACE_RESTRICT_VARIABLE_ORDERS_INCLUDE,            TRDDLIF_NONE },
 		{ TRIT_COND_CARGO,                                            STR_TRACE_RESTRICT_VARIABLE_CARGO,                     TRDDLIF_NONE },
 		{ TRIT_COND_LOAD_PERCENT,                                     STR_TRACE_RESTRICT_VARIABLE_LOAD_PERCENT,              TRDDLIF_NONE },
 		{ TRIT_COND_ENTRY_DIRECTION,                                  STR_TRACE_RESTRICT_VARIABLE_ENTRY_DIRECTION,           TRDDLIF_NONE },


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Description

Adds the "orders include station" conditional for signal programming.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->

The wording is weird due to the if-statement GUI layout (reads as `If orders include station is A`)


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
