### PR TITLE
Changed leftover ticks setting to also show leftover seconds

### DIFF
--- a/src/lang/extra/english.txt
+++ b/src/lang/extra/english.txt
@@ -509,8 +509,10 @@ STR_CONFIG_SETTING_AUTO_TIMETABLE_BY_DEFAULT_HELPTEXT           :Choose whether 
 STR_CONFIG_SETTING_TIMETABLE_SEPARATION_BY_DEFAULT              :Use timetable to ensure vehicle separation by default: {STRING2}
 STR_CONFIG_SETTING_TIMETABLE_SEPARATION_BY_DEFAULT_HELPTEXT     :Choose whether to ensure separation of vehicles should be automatically enabled for new vehicles
 
-STR_CONFIG_SETTING_TIMETABLE_LEFTOVER_TICKS                     :Show leftover ticks in timetable: {STRING2}
-STR_CONFIG_SETTING_TIMETABLE_LEFTOVER_TICKS_HELPTEXT            :When converting from ticks to days/minutes in timetables, also show any leftover ticks
+STR_CONFIG_SETTING_TIMETABLE_LEFTOVER_TIME                      :Show leftover time in timetable: {STRING2}
+STR_CONFIG_SETTING_TIMETABLE_LEFTOVER_TIME_HELPTEXT             :When converting from ticks to days/minutes in timetables, also show any leftover ticks or seconds
+STR_CONFIG_SETTING_TIMETABLE_LEFTOVER_TIME_TICKS                :Ticks
+STR_CONFIG_SETTING_TIMETABLE_LEFTOVER_TIME_SECONDS              :Seconds
 
 STR_CONFIG_SETTING_OVERRIDE_TIME_SETTINGS                       :Use client timetable time settings instead of savegame time settings: {STRING2}
 STR_CONFIG_SETTING_OVERRIDE_TIME_SETTINGS_HELPTEXT              :Select whether to use local client settings for timetable time display, instead of the time settings in the savegame.
@@ -1916,6 +1918,7 @@ STR_TIMETABLE_HOURS_MINUTES                                     :{COMMA}{NBSP}ho
 STR_TIMETABLE_MINUTES_SUFFIX                                    : ({STRING2})
 
 STR_TIMETABLE_LEFTOVER_TICKS                                    : + {COMMA} tick{P "" s}
+STR_TIMETABLE_LEFTOVER_SECONDS                                  : {COMMA} second{P "" s}
 
 STR_TIMETABLE_AUTOMATE                                          :{BLACK}Automate
 STR_TIMETABLE_AUTOMATE_TOOLTIP                                  :{BLACK}Manage the timetables automatically by updating the values for each journey

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -922,7 +922,7 @@ SettingsContainer &GetSettingsTree()
 				}
 
 				timetable->Add(new SettingEntry("gui.timetable_in_ticks"));
-				timetable->Add(new SettingEntry("gui.timetable_leftover_ticks"));
+				timetable->Add(new SettingEntry("gui.timetable_leftover_time"));
 				timetable->Add(new SettingEntry("gui.timetable_arrival_departure"));
 				timetable->Add(new SettingEntry("gui.timetable_start_text_entry"));
 			}

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -166,6 +166,14 @@ enum PublicRoadsConstruction : uint8_t {
 	PRC_END
 };
 
+/** Settings related to the timetable leftover time display. */
+enum TimetableLeftoverTimeSetting : uint8_t {
+	TLT_OFF = 0,         ///< Do not show leftover time.
+	TLT_TICKS = 1,       ///< Show leftover time as ticks.
+	TLT_SECONDS = 2,     ///< Show leftover time as seconds.
+};
+
+
 /** Deaptures conditional jump result */
 enum DeparturesConditionalJumpResult : uint8_t {
 	DCJD_BEGIN = 0,
@@ -300,7 +308,7 @@ struct GUISettings : public TimeSettings {
 	CalTime::Year coloured_news_year;                            ///< when does newspaper become coloured?
 	bool        override_time_settings;                          ///< Whether to override time display settings stored in savegame.
 	bool        timetable_in_ticks;                              ///< whether to show the timetable in ticks rather than days
-	bool        timetable_leftover_ticks;                        ///< whether to show leftover ticks after converting to minutes/days, in the timetable
+	TimetableLeftoverTimeSetting timetable_leftover_time;        ///< whether to show leftover time in ticks or seconds after converting to minutes/days, in the timetable
 	bool        timetable_start_text_entry;                      ///< whether to enter timetable start times as text (hhmm format)
 	uint8_t     date_with_time;                                  ///< whether to show the month and year with the time
 	bool        quick_goto;                                      ///< Allow quick access to 'goto button' in vehicle orders window

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1766,7 +1766,7 @@ static void FormatString(StringBuilder builder, std::string_view str_arg, String
 						const int64_t ticks = args.GetNextParameter<int64_t>();
 						const int64_t ratio = TimetableDisplayUnitSize();
 						const int64_t units = ticks / ratio;
-						const int64_t leftover = _settings_client.gui.timetable_leftover_ticks ? ticks % ratio : 0;
+						const int64_t leftover = (_settings_client.gui.timetable_leftover_time != TLT_OFF) ? ticks % ratio : 0;
 						auto tmp_params = MakeParameters(units);
 						FormatString(builder, GetStringPtr(str), tmp_params);
 						if (b == SCC_TT_TICKS_LONG && _settings_time.time_in_minutes && units > 59) {
@@ -1779,9 +1779,19 @@ static void FormatString(StringBuilder builder, std::string_view str_arg, String
 							);
 							FormatString(builder, GetStringPtr(STR_TIMETABLE_MINUTES_SUFFIX), tmp_params);
 						}
-						if (leftover != 0) {
-							auto tmp_params = MakeParameters(leftover);
-							FormatString(builder, GetStringPtr(STR_TIMETABLE_LEFTOVER_TICKS), tmp_params);
+						if (leftover != 0 && _settings_client.gui.timetable_leftover_time != TLT_OFF) {
+							StringID leftover_str;
+							int64_t leftover_value;
+							if (_settings_client.gui.timetable_leftover_time == TLT_SECONDS && _settings_time.time_in_minutes) {
+								/* Convert leftover ticks to seconds (only when using minutes mode) */
+								leftover_value = (leftover * 60) / _settings_time.ticks_per_minute;
+								leftover_str = STR_TIMETABLE_LEFTOVER_SECONDS;
+							} else {
+								leftover_value = leftover;
+								leftover_str = STR_TIMETABLE_LEFTOVER_TICKS;
+							}
+							auto leftover_params = MakeParameters(leftover_value);
+							FormatString(builder, GetStringPtr(leftover_str), leftover_params);
 						}
 					}
 					break;

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -76,6 +76,13 @@ static const SettingDescEnumEntry _cycle_signal_types[] = {
 { 0, STR_NULL }
 };
 
+static const SettingDescEnumEntry _timetable_leftover_time[] = {
+{ TLT_OFF,                  STR_CONFIG_SETTING_OFF },
+{ TLT_TICKS,                STR_CONFIG_SETTING_TIMETABLE_LEFTOVER_TIME_TICKS },
+{ TLT_SECONDS,              STR_CONFIG_SETTING_TIMETABLE_LEFTOVER_TIME_SECONDS },
+{ 0, STR_NULL }
+};
+
 const SettingTable _gui_settings{
 [post-amble]
 };
@@ -744,12 +751,14 @@ strhelp  = STR_CONFIG_SETTING_TIMETABLE_IN_TICKS_HELPTEXT
 post_cb  = ChangeTimetableInTicksMode
 cat      = SC_EXPERT
 
-[SDTC_BOOL]
-var      = gui.timetable_leftover_ticks
+[SDTC_ENUM]
+var      = gui.timetable_leftover_time
+type     = SLE_UINT8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::Patch
-def      = false
-str      = STR_CONFIG_SETTING_TIMETABLE_LEFTOVER_TICKS
-strhelp  = STR_CONFIG_SETTING_TIMETABLE_LEFTOVER_TICKS_HELPTEXT
+def      = 0
+enumlist = _timetable_leftover_time
+str      = STR_CONFIG_SETTING_TIMETABLE_LEFTOVER_TIME
+strhelp  = STR_CONFIG_SETTING_TIMETABLE_LEFTOVER_TIME_HELPTEXT
 post_cb  = InvalidateVehTimetableWindow
 cat      = SC_EXPERT
 

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -887,7 +887,7 @@ struct TimetableWindow : GeneralVehicleWindow {
 					StringID str;
 					if (!v->orders->IsCompleteTimetable()) {
 						str = STR_TIMETABLE_TOTAL_TIME_INCOMPLETE;
-					} else if (!_settings_client.gui.timetable_in_ticks && !_settings_client.gui.timetable_leftover_ticks && total_time % TimetableDisplayUnitSize() != 0) {
+					} else if (!_settings_client.gui.timetable_in_ticks && _settings_client.gui.timetable_leftover_time == TLT_OFF && total_time % TimetableDisplayUnitSize() != 0) {
 						str = STR_TIMETABLE_APPROX_TIME;
 					} else {
 						str = STR_TIMETABLE_TOTAL_TIME;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
Changed the "leftover ticks" boolean setting into a generic "leftover time" enumerator and added a "Seconds" option.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
The seconds are calculated using the ticks per minute value
<img width="500" height="400" alt="image" src="https://github.com/user-attachments/assets/8f6618fb-e914-4333-a9a2-0a57ab6b5268" />

<img width="650" height="330" alt="image" src="https://github.com/user-attachments/assets/5d1aba31-93d3-4353-80e3-4cd1d4f5ef72" />


The seconds only show when you use the "Show timetable time in minutes" setting (see below)
<img width="700" height="700" alt="image" src="https://github.com/user-attachments/assets/3c5194cd-6acc-4dff-addd-9ea596c24fa6" />


And it follows the leftover ticks logic in not showing if all time is shown in only ticks.
<img width="500" height="700" alt="image" src="https://github.com/user-attachments/assets/425bec23-24d8-4906-ac5a-cc1f36901c97" />




<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
As always with my code the english.txt strings are pretty good, but could be improved for clarity
I used 0, 1, 2 in the SettingDescEnumEntry following most of the other enum settings, but this might not be best practice.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
