### PR TITLE
Path-find through drive-throught depots

### DIFF
--- a/src/pathfinder/follow_track.hpp
+++ b/src/pathfinder/follow_track.hpp
@@ -151,7 +151,7 @@ struct CFollowTrackT
 			 * that function failed can have to do with a
 			 * missing road bit, or inability to connect the
 			 * different bits due to slopes. */
-			if (IsRoadTT() && !this->IsTram() && this->TryReverse()) return true;
+			if (((IsRoadTT() && !this->IsTram()) || IsRailTT()) && this->TryReverse()) return true;
 
 			/* CanEnterNewTile already set a reason.
 			 * Do NOT overwrite it (important for example for EC_RAIL_ROAD_TYPE).
@@ -326,7 +326,22 @@ protected:
 		}
 		if (IsRailTT() && IsDepotTypeTile(this->new_tile, TT())) {
 			DiagDirection exitdir = GetRailDepotDirection(this->new_tile);
-			if (ReverseDiagDir(exitdir) != this->exitdir) {
+			/* new and old tile are both depots */
+			if (IsDepotTypeTile(this->old_tile, TT())) {
+				DiagDirection oldExitdir = GetRailDepotDirection(this->new_tile);
+				if (exitdir != oldExitdir && ReverseDiagDir(exitdir) != oldExitdir) {
+					/* depots are 90 degress to each other */
+					this->err = EC_NO_WAY;
+					return false;
+				}
+				if (GetTileMaxZ(this->new_tile) != GetTileMaxZ(this->old_tile)) {
+					/* depots are on different level */
+					this->err = EC_NO_WAY;
+					return false;
+				}
+
+			}
+			else if (ReverseDiagDir(exitdir) != this->exitdir) {
 				this->err = EC_NO_WAY;
 				return false;
 			}
@@ -416,8 +431,8 @@ protected:
 	inline bool ForcedReverse()
 	{
 		/* rail and road depots cause reversing */
-		if (!IsWaterTT() && IsDepotTypeTile(this->old_tile, TT())) {
-			DiagDirection exitdir = IsRailTT() ? GetRailDepotDirection(this->old_tile) : GetRoadDepotDirection(this->old_tile);
+		if (!IsWaterTT() && !IsRailTT() && IsDepotTypeTile(this->old_tile, TT())) {
+			DiagDirection exitdir = GetRoadDepotDirection(this->old_tile);
 			if (exitdir != this->exitdir) {
 				/* reverse */
 				this->new_tile = this->old_tile;
@@ -463,6 +478,17 @@ protected:
 				/* we have some trackdirs reachable after reversal */
 				return true;
 			}
+		}
+		if (IsRailTT() && IsDepotTypeTile(this->old_tile, TT())) {
+			/* reverse if this is rail depot that isn't drive-through */
+			this->new_tile = this->old_tile;
+			this->new_td_bits = TrackdirToTrackdirBits(ReverseTrackdir(this->old_td));
+			this->exitdir = GetRailDepotDirection(this->old_tile);
+			this->tiles_skipped = 0;
+			this->is_tunnel = false;
+			this->is_bridge = false;
+			this->is_station = false;
+			return true;
 		}
 		this->err = EC_NO_WAY;
 		return false;


### PR DESCRIPTION
This PR is not finished, there are issues I wasn't able to resolve. I'm uploading the code in case someone else is interested in picking it up and/or offering some advice.

Modify pathfinder to work with drive-through depots.

What works:
 - pathfinding through depots
 - no false positives (90 deg, different height levels)

What doesn't work:
 - MUST FIX: drive through depots do not add penalty
 - not fatal: pathfinder doesn't detect that train can reverse in drive through depots (that is, multiple depots followed by more rail; dead-end "drive through" depots are not affected)
