### PR TITLE
Better town placement

### DIFF
--- a/src/lang/extra/english.txt
+++ b/src/lang/extra/english.txt
@@ -2547,3 +2547,7 @@ STR_ORDERLIST_JSON_CONFIRM_OVERRIDE_QUERY_CAPTION               :{WHITE}Confirm 
 
 STR_ORDER_UNKNOWN_ERROR                                         :[Error] Unknown error
 STR_ORDER_PARSE_ERROR                                           :[Error] This order could not be parsed
+
+STR_CONFIG_SETTING_BETTER_TOWN_PLACEMENT                        :Better town placement
+STR_CONFIG_SETTING_BETTER_TOWN_PLACEMENT_HELPTEXT               :When placing a town, prefer locations near sea, lakes or rivers, or in a valley.
+STR_CONFIG_SETTING_BETTER_TOWN_PLACEMENT_RADIUS                 :Search radius for better town placement: {STRING2}

--- a/src/lang/extra/french.txt
+++ b/src/lang/extra/french.txt
@@ -109,3 +109,7 @@ STR_COMPANY_VIEW_PASSWORD_TOOLTIP                               :{BLACK}Permet d
 STR_COMPANY_VIEW_SET_PASSWORD                                   :{BLACK}Choisir le mot de passe de la compagnie
 
 # JSON messages
+
+STR_CONFIG_SETTING_BETTER_TOWN_PLACEMENT                        :Meilleur emplacement pour les villes
+STR_CONFIG_SETTING_BETTER_TOWN_PLACEMENT_HELPTEXT               :Lors de la construction d'une ville, recherche dans le voisinage un endroit plus propice. Privilégie les vallées et endroits proche de l'eau.
+STR_CONFIG_SETTING_BETTER_TOWN_PLACEMENT_RADIUS                 :Rayon dans lequel rechercher un meilleur emplacement : {STRING}

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -1152,6 +1152,9 @@ SettingsContainer &GetSettingsTree()
 			genworld->Add(new SettingEntry("game_creation.amount_of_rocks"));
 			genworld->Add(new SettingEntry("game_creation.height_affects_rocks"));
 			genworld->Add(new SettingEntry("game_creation.build_public_roads"));
+			genworld->Add(new SettingEntry("game_creation.better_town_placement"));
+			auto better_town_placement_hide = []() -> bool { return !GetGameSettings().game_creation.better_town_placement; };
+			genworld->Add(new ConditionallyHiddenSettingEntry("game_creation.better_town_placement_radius", better_town_placement_hide));
 		}
 
 		SettingsPage *environment = main->Add(new SettingsPage(STR_CONFIG_SETTING_ENVIRONMENT));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -589,6 +589,8 @@ struct GameCreationSettings {
 	uint8_t  amount_of_rocks;                ///< the amount of rocks
 	uint8_t  height_affects_rocks;           ///< the affect that map height has on rocks
 	PublicRoadsConstruction build_public_roads; ///< build public roads connecting towns
+	bool     better_town_placement;             ///< use better town placement?
+	uint8_t  better_town_placement_radius;      ///< search radius for better town placement
 };
 
 /** Settings related to construction in-game */

--- a/src/table/settings/world_settings.ini
+++ b/src/table/settings/world_settings.ini
@@ -514,6 +514,27 @@ strhelp  = STR_CONFIG_SETTING_BUILD_PUBLIC_ROADS_HELPTEXT
 strval   = STR_CONFIG_SETTING_BUILD_PUBLIC_ROADS_NONE
 patxname = ""public_roads.game_creation.build_public_roads""
 
+[SDT_BOOL]
+var      = game_creation.better_town_placement
+flags    = SettingFlag::NewgameOnly, SettingFlag::SceneditToo, SettingFlag::Patch
+def      = false
+cat      = SC_ADVANCED
+str      = STR_CONFIG_SETTING_BETTER_TOWN_PLACEMENT
+strhelp  = STR_CONFIG_SETTING_BETTER_TOWN_PLACEMENT_HELPTEXT
+post_cb  = [](auto) { InvalidateWindowClassesData(WC_GAME_OPTIONS); }
+
+[SDT_VAR]
+var      = game_creation.better_town_placement_radius
+type     = SLE_UINT8
+flags    = SettingFlag::NewgameOnly, SettingFlag::SceneditToo, SettingFlag::Patch
+def      = 5
+min      = 5
+max      = 25
+interval = 5
+str      = STR_CONFIG_SETTING_BETTER_TOWN_PLACEMENT_RADIUS
+cat      = SC_EXPERT
+strval   = STR_JUST_COMMA
+
 [SDT_VAR]
 var      = construction.map_height_limit
 type     = SLE_UINT8


### PR DESCRIPTION
## Motivation / Problem

The original town placement is purely random and sometimes not very logical: towns may appear in the middle of nowhere on top of mountains, while a nice valley with a river would be a much more suitable location.
In real life, cities and villages are most often built near water (sea or rivers), as it provides significant military and economic advantages. They also tend to be located in valleys rather than on snowy mountain peaks.


## Description

This patch introduces a feature that scouts around the initially selected random location to find a better spot for placing a town.
Lower elevations provide a bonus, and locations near rivers, lakes, or the sea receive an even higher bonus.
The spot with the highest total score is selected.


## Limitations

This feature tends to place towns near water. This may have consequences on town growth later in the game.