### PR TITLE
Add dock picker functionality

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -163,6 +163,7 @@ add_files(
     disaster_vehicle.cpp
     disaster_vehicle.h
     dock_gui.cpp
+    dock_gui.h
     driver.cpp
     driver.h
     dropdown.cpp

--- a/src/dock_gui.h
+++ b/src/dock_gui.h
@@ -1,0 +1,21 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file dock_gui.h Functions/types related to the dock GUIs. */
+
+#ifndef DOCK_GUI_H
+#define DOCK_GUI_H
+
+#include "tile_type.h"
+
+struct Window;
+
+Window *ShowBuildDocksToolbar();
+Window *ShowBuildDocksScenToolbar();
+void ShowBuildDocksToolbarFromTile(TileIndex tile);
+
+#endif /* DOCK_GUI_H */

--- a/src/gui.h
+++ b/src/gui.h
@@ -30,10 +30,6 @@ void ShowGameOptions();
 /* train_gui.cpp */
 void ShowOrdersWindow(const Vehicle *v);
 
-/* dock_gui.cpp */
-Window *ShowBuildDocksToolbar();
-Window *ShowBuildDocksScenToolbar();
-
 /* airport_gui.cpp */
 Window *ShowBuildAirToolbar();
 

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -20,6 +20,8 @@
 #include "rail_gui.h"
 #include "road.h"
 #include "road_gui.h"
+#include "dock_gui.h"
+#include "water_map.h"
 #include "date_func.h"
 #include "vehicle_func.h"
 #include "sound_func.h"
@@ -1160,6 +1162,11 @@ static void UsePickerTool(TileIndex tile)
 					ShowBuildRoadStopPickerAndSelect(station_type, GetRoadStopSpec(tile), HasRoadTypeRoad(tile) ? RTT_ROAD : RTT_TRAM);
 					break;
 
+				case StationType::Dock:
+				case StationType::Buoy:
+					ShowBuildDocksToolbarFromTile(tile);
+					break;
+
 				default:
 					break;
 			}
@@ -1176,9 +1183,27 @@ static void UsePickerTool(TileIndex tile)
 					ShowBuildRoadToolbarFromTile(tile);
 					break;
 
+				case TRANSPORT_WATER:
+					ShowBuildDocksToolbarFromTile(tile);
+					break;
+
 				default:
 					break;
 			}
+			break;
+
+		case MP_WATER:
+			/* Handle canals, rivers, and locks by opening the waterways toolbar.
+			 * Rivers only work if river building is enabled or in scenario editor. */
+			if (IsLock(tile) || IsCanal(tile)) {
+				ShowBuildDocksToolbarFromTile(tile);
+			} else if (IsRiver(tile) && (_settings_game.construction.enable_build_river || _game_mode == GM_EDITOR)) {
+				ShowBuildDocksToolbarFromTile(tile);
+			/* Depots for now only opens waterways toolbar like other depots */
+			} else if (GetWaterTileType(tile) == WATER_TILE_DEPOT) {
+				ShowBuildDocksToolbarFromTile(tile);
+			}
+			/* Sea & coast tiles are ignored*/
 			break;
 
 		case MP_OBJECT: {


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Water tiles such as docks buoys, rivers canals etc have not had picker tool functionality like Rail/Road currently does.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Pretty much just ripped the relevant parts from rail/road picker code to follow the same logic (using picker tool on any of the water infrastructure just opens up the toolbar and then specifically the docks and station windows are also called when relevant). Water tiles are much more basic than road and esp rail tiles, so a lot less code is needed.

<img width="1390" height="760" alt="image" src="https://github.com/user-attachments/assets/7b07e61e-d500-4f17-8052-d5c0c11c8c2d" />


<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Will handle ship depots separately in a couple of days with road/rail depots, so for now ~~nothing happens when you pick them~~ the waterways toolbar opens up (like canals).
Didnt do anything to handle the fact that buoys kinda dont seem to have an owner like regular waypoints, but from testing this didnt seem to be an issue.
Also didn't mess with things like oil rigs with shared stations, but I didn't see any need to as the picker tool already picks up the industry.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
