### PR TITLE
Codefix: Add missing sys/stat.h include

### DIFF
--- a/src/os/unix/crashlog_unix.cpp
+++ b/src/os/unix/crashlog_unix.cpp
@@ -25,6 +25,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
 
 #if defined(WITH_DBG_GDB)
 #include <sys/syscall.h>


### PR DESCRIPTION
## Motivation / Problem
I can't compile the game on FreeBSD 15.0 x86_64 with Clang 19.1.7, but this is just due to a single include missing:
```
./src/os/unix/crashlog_unix.cpp:286:57: error: use of undeclared identifier 'S_IRUSR'
  286 |                 int fd = open(filename, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
      |                                                                       ^
```

## Description
This change adds the include.
