### PR TITLE
 Feature: Add linear maintenance setting to infrastructure maintenance

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -276,6 +276,7 @@ add_files(
     livery.h
     load_check.h
     main_gui.cpp
+    maintenance_func.h
     map.cpp
     map_func.h
     map_type.h

--- a/src/lang/extra/english.txt
+++ b/src/lang/extra/english.txt
@@ -2576,3 +2576,6 @@ STR_PICKER_ROADSTOP_BUS_RANDOM_TOOLTIP                          :Place random bu
 STR_PICKER_ROADSTOP_TRUCK_RANDOM_TOOLTIP                        :Place random lorry stations from the selected collection
 STR_PICKER_OBJECT_RANDOM_TOOLTIP                                :Place random 1x1 objects from the selected collection
 STR_PICKER_HOUSE_RANDOM_TOOLTIP                                 :Place random 1x1 houses from the selected collection
+
+STR_CONFIG_SETTING_LINEAR_MAINTENANCE                           :Linear maintenance growth: {STRING2}
+STR_CONFIG_SETTING_LINEAR_MAINTENANCE_HELPTEXT                  :When enabled, infrastructure maintenance costs grow linearly rather than polynomially

--- a/src/lang/extra/english_AU.txt
+++ b/src/lang/extra/english_AU.txt
@@ -142,3 +142,6 @@ STR_INTRO_TOOLTIP_NEWGRF_SETTINGS                               :{BLACK}Open New
 STR_INTRO_TOOLTIP_AI_SETTINGS                                   :{BLACK}Open AI settings
 STR_INTRO_TOOLTIP_GAMESCRIPT_SETTINGS                           :{BLACK}Open Game script settings
 STR_INTRO_CAPTION_TRADITIONAL                                   :{WHITE}OpenTTD {REV}
+
+STR_CONFIG_SETTING_LINEAR_MAINTENANCE                           :Linear maintenance growth: {STRING}
+STR_CONFIG_SETTING_LINEAR_MAINTENANCE_HELPTEXT                  :When enabled, infrastructure maintenance costs grow linearly rather than polynomially

--- a/src/lang/extra/english_US.txt
+++ b/src/lang/extra/english_US.txt
@@ -143,3 +143,6 @@ STR_INTRO_TOOLTIP_NEWGRF_SETTINGS                               :{BLACK}Open New
 STR_INTRO_TOOLTIP_AI_SETTINGS                                   :{BLACK}Open AI settings
 STR_INTRO_TOOLTIP_GAMESCRIPT_SETTINGS                           :{BLACK}Open Game script settings
 STR_INTRO_CAPTION_TRADITIONAL                                   :{WHITE}OpenTTD {REV}
+
+STR_CONFIG_SETTING_LINEAR_MAINTENANCE                           :Linear maintenance growth: {STRING}
+STR_CONFIG_SETTING_LINEAR_MAINTENANCE_HELPTEXT                  :When enabled, infrastructure maintenance costs grow linearly rather than polynomially

--- a/src/lang/extra/polish.txt
+++ b/src/lang/extra/polish.txt
@@ -117,3 +117,6 @@ STR_INTRO_TOOLTIP_NEWGRF_SETTINGS                               :{BLACK}Otwórz 
 STR_INTRO_TOOLTIP_AI_SETTINGS                                   :{BLACK}Otwórz ustawienia SI
 STR_INTRO_TOOLTIP_GAMESCRIPT_SETTINGS                           :{BLACK}Otwórz ustawienia Game Script
 STR_INTRO_CAPTION_TRADITIONAL                                   :{WHITE}OpenTTD {REV}
+
+STR_CONFIG_SETTING_LINEAR_MAINTENANCE                           :Liniowy wzrost kosztu utrzymania: {STRING}
+STR_CONFIG_SETTING_LINEAR_MAINTENANCE_HELPTEXT                  :Po włączeniu, koszty utrzymania infrastruktury rosną liniowo zamiast wielomianowo

--- a/src/maintenance_func.h
+++ b/src/maintenance_func.h
@@ -1,0 +1,28 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file maintenance_func.h Functions related to infrastructure maintenance. */
+
+#ifndef MAINTENANCE_FUNC_H
+#define MAINTENANCE_FUNC_H
+
+#include "settings_type.h"
+#include "core/math_func.hpp"
+
+/**
+ * Calculates the scaling factor to use for maintenance costs.
+ * @param total_num Number of infrastructure items.
+ * @param linear_scale Scaling factor to use in linear mode.
+ * @return Scaling factor.
+ */
+inline uint32_t GetMaintenanceCostScale(uint32_t total_num, uint32_t linear_scale)
+{
+	if (_settings_game.economy.linear_maintenance) return linear_scale;
+	return 1 + IntSqrt(total_num);
+}
+
+#endif /* MAINTENANCE_FUNC_H */

--- a/src/rail.cpp
+++ b/src/rail.cpp
@@ -15,6 +15,7 @@
 #include "company_base.h"
 #include "engine_base.h"
 #include "economy_func.h"
+#include "maintenance_func.h"
 
 #include "table/track_data.h"
 
@@ -313,7 +314,8 @@ RailType GetRailTypeByLabel(RailTypeLabel label, bool allow_alternate_labels)
 Money RailMaintenanceCost(RailType railtype, uint32_t num, uint32_t total_num)
 {
 	dbg_assert(railtype < RAILTYPE_END);
-	return (_price[PR_INFRASTRUCTURE_RAIL] * GetRailTypeInfo(railtype)->maintenance_multiplier * num * (1 + IntSqrt(total_num))) >> 11; // 4 bits fraction for the multiplier and 7 bits scaling.
+	/* 4 bits fraction for the multiplier and 7 bits scaling. 72 is roughly equivalent to the polynomial maintenance cost at 5000 pieces. */
+	return (_price[PR_INFRASTRUCTURE_RAIL] * GetRailTypeInfo(railtype)->maintenance_multiplier * num * GetMaintenanceCostScale(total_num, 72)) >> 11;
 }
 
 /**
@@ -323,5 +325,6 @@ Money RailMaintenanceCost(RailType railtype, uint32_t num, uint32_t total_num)
  */
 Money SignalMaintenanceCost(uint32_t num)
 {
-	return (_price[PR_INFRASTRUCTURE_RAIL] * 15 * num * (1 + IntSqrt(num))) >> 8; // 1 bit fraction for the multiplier and 7 bits scaling.
+	/* 1 bit fraction for the multiplier and 7 bits scaling. 33 is roughly equivalent to the polynomial maintenance cost at 1000 pieces. */
+	return (_price[PR_INFRASTRUCTURE_RAIL] * 15 * num * GetMaintenanceCostScale(num, 33)) >> 8;
 }

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -45,6 +45,7 @@
 #include "landscape_cmd.h"
 #include "rail_cmd.h"
 #include "economy_func.h"
+#include "maintenance_func.h"
 
 #include "table/strings.h"
 #include "table/roadtypes.h"
@@ -475,7 +476,8 @@ void UpdateCompanyRoadInfrastructure(RoadType rt, Owner o, int count)
 Money RoadMaintenanceCost(RoadType roadtype, uint32_t num, uint32_t total_num)
 {
 	dbg_assert(roadtype < ROADTYPE_END);
-	return (_price[PR_INFRASTRUCTURE_ROAD] * GetRoadTypeInfo(roadtype)->maintenance_multiplier * num * (1 + IntSqrt(total_num))) >> 12;
+	/* 33 is roughly equivalent to the polynomial maintenance cost at 1000 pieces. */
+	return (_price[PR_INFRASTRUCTURE_ROAD] * GetRoadTypeInfo(roadtype)->maintenance_multiplier * num * GetMaintenanceCostScale(total_num, 33)) >> 12;
 }
 
 /** Invalid RoadBits on slopes.  */

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -1006,6 +1006,7 @@ SettingsContainer &GetSettingsTree()
 			accounting->Add(new SettingEntry("difficulty.subsidy_duration"));
 			accounting->Add(new SettingEntry("economy.feeder_payment_share"));
 			accounting->Add(new SettingEntry("economy.infrastructure_maintenance"));
+			accounting->Add(new ConditionallyHiddenSettingEntry("economy.linear_maintenance", []() -> bool { return !GetGameSettings().economy.infrastructure_maintenance; }));
 			accounting->Add(new SettingEntry("difficulty.vehicle_costs"));
 			accounting->Add(new SettingEntry("difficulty.vehicle_costs_in_depot"));
 			accounting->Add(new SettingEntry("difficulty.vehicle_costs_when_stopped"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -833,6 +833,7 @@ struct EconomySettings {
 	bool     allow_town_bridges;             ///< towns are allowed to build bridges
 	bool     default_allow_town_growth;      ///< town growth is allowed per-town by default
 	bool     infrastructure_maintenance;     ///< enable monthly maintenance fee for owner infrastructure
+	bool     linear_maintenance;             ///< set maintenance costs to grow linearly rather than polynomially
 	TimekeepingUnits timekeeping_units;      ///< time units to use for the game economy, either calendar or wallclock
 	uint16_t minutes_per_calendar_year;      ///< minutes per calendar year. Special value 0 means that calendar time is frozen.
 	uint16_t town_cargo_scale;               ///< scale cargo production of towns by this percentage.

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -15,6 +15,7 @@
 #include "viewport_kdtree.h"
 #include "date_func.h"
 #include "economy_func.h"
+#include "maintenance_func.h"
 #include "command_func.h"
 #include "news_func.h"
 #include "aircraft.h"
@@ -754,7 +755,8 @@ StationRect& StationRect::operator = (const Rect &src)
  */
 Money StationMaintenanceCost(uint32_t num)
 {
-	return (_price[PR_INFRASTRUCTURE_STATION] * num * (1 + IntSqrt(num))) >> 7; // 7 bits scaling.
+	/* 7 bits scaling. 23 is roughly equivalent to the polynomial maint cost at 500 pieces. */
+	return (_price[PR_INFRASTRUCTURE_STATION] * num * GetMaintenanceCostScale(num, 23)) >> 7;
 }
 
 /**

--- a/src/table/settings/economy_settings.ini
+++ b/src/table/settings/economy_settings.ini
@@ -764,6 +764,15 @@ from     = SLV_166
 def      = false
 str      = STR_CONFIG_SETTING_INFRASTRUCTURE_MAINTENANCE
 strhelp  = STR_CONFIG_SETTING_INFRASTRUCTURE_MAINTENANCE_HELPTEXT
+post_cb  = [](auto) { InvalidateWindowClassesData(WC_COMPANY_INFRASTRUCTURE); InvalidateWindowClassesData(WC_GAME_OPTIONS); }
+cat      = SC_BASIC
+
+[SDT_BOOL]
+var      = economy.linear_maintenance
+flags    = SettingFlag::Patch
+def      = false
+str      = STR_CONFIG_SETTING_LINEAR_MAINTENANCE
+strhelp  = STR_CONFIG_SETTING_LINEAR_MAINTENANCE_HELPTEXT
 post_cb  = [](auto) { InvalidateWindowClassesData(WC_COMPANY_INFRASTRUCTURE); }
 cat      = SC_BASIC
 

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -25,6 +25,7 @@
 #include "sound_func.h"
 #include "company_func.h"
 #include "economy_func.h"
+#include "maintenance_func.h"
 #include "clear_map.h"
 #include "tree_map.h"
 #include "aircraft.h"
@@ -591,7 +592,8 @@ CommandCost CmdBuildCanal(DoCommandFlags flags, TileIndex tile, TileIndex start_
  */
 Money CanalMaintenanceCost(uint32_t num)
 {
-	return (_price[PR_INFRASTRUCTURE_WATER] * num * (1 + IntSqrt(num))) >> 6; // 6 bits scaling.
+	/* 6 bits scaling. 11 is roughly equivalent to the polynomial maint cost at 100 pieces. */
+	return (_price[PR_INFRASTRUCTURE_WATER] * num * GetMaintenanceCostScale(num, 11)) >> 6;
 }
 
 


### PR DESCRIPTION
## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
Infrastructure maintenance currently grows at a polynomial rate, specifically meaning that the cost of each individual piece of infrastructure (say, a road piece) is multiplied by `x^1.5+x`, where `x` is the number of road pieces your company owns. This was originally intended to make the game more difficult, but it results in a gameplay antipattern at a certain size of company where the most optimal thing you can do is to stop playing the game because any infrastructure you build is a net drain. There is a major gap between "no maintenance at all" and "maintenance starts small but suddenly grows increasingly oppressive" that is filled by a linear growth option, which should appeal to people who want the game to offer a reasonable financial challenge but not one which (eventually, late in a game) requires everything you do to be fully optimized.

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
This PR adds a setting under the infrastructure maintenance setting that allows the player to make the maintenance cost grow linearly rather than polynomially. This means that your first piece of track will cost as much to maintain as your 1,000th, whereas currently each piece of track you add increases the cost of maintenance for all existing pieces of track.

A company with 5,000 track pieces (which are different from track tiles in a couple niche ways), 1,000 signals, 1,000 road pieces, 500 station tiles, and 100 tiles of water infra will cost roughly the same in maintenance on either original or linear maintenance costs. Smaller companies will cost comparatively more on linear while bigger companies will cost comparatively less.

Airports are unaffected, because they were already linear (You're not expected to build enough airports for a growth factor to have a major effect).

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
Ideally the setting would be a dropdown, with options "disabled", "original", and "linear", but I don't think that could preserve people's existing settings, so I added a separate toggle.

The balance is somewhat arbitrary. I had to increase the cost of all types of infrastructure by a factor to make up for removing the cost growth. I chose this factor by taking a save where my friend started to struggle with going underwater from the maintenance costs while not trying to play very well, looking at how much infra they had of each type, and making it so that a company of roughly that size would be paying the same amount whether on original or linear maintenance costs.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
