### PR TITLE
Add warning when cargo at station is overflowing

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1963,6 +1963,9 @@ STR_CONFIG_SETTING_NEWS_NEW_VEHICLES_HELPTEXT                   :Display a newsp
 STR_CONFIG_SETTING_NEWS_CHANGES_ACCEPTANCE                      :Changes to cargo acceptance: {STRING2}
 STR_CONFIG_SETTING_NEWS_CHANGES_ACCEPTANCE_HELPTEXT             :Display messages about stations changing acceptance of some cargoes
 
+STR_CONFIG_SETTING_NEWS_CARGO_FLOW                              :Overflowing cargo at station: {STRING2}
+STR_CONFIG_SETTING_NEWS_CARGO_FLOW_HELPTEXT                     :Warn about stations where cargo is accumulating.{}The detection is based on shape of the cargo history graph, not on specific amount threshold.
+
 STR_CONFIG_SETTING_NEWS_SUBSIDIES                               :Subsidies: {STRING2}
 STR_CONFIG_SETTING_NEWS_SUBSIDIES_HELPTEXT                      :Display a newspaper about subsidy related events
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -902,6 +902,8 @@ STR_NEWS_INDUSTRY_CLOSURE_GENERAL                               :{BIG_FONT}{BLAC
 STR_NEWS_INDUSTRY_CLOSURE_SUPPLY_PROBLEMS                       :{BIG_FONT}{BLACK}Supply problems cause {STRING2} to announce imminent closure!
 STR_NEWS_INDUSTRY_CLOSURE_LACK_OF_TREES                         :{BIG_FONT}{BLACK}Lack of nearby trees causes {STRING2} to announce imminent closure!
 
+STR_STATION_CARGO_OVERFLOW                                      :{WHITE}{CARGO_LIST} overflowing at {STATION}
+
 STR_NEWS_EURO_INTRODUCTION                                      :{BIG_FONT}{BLACK}European Monetary Union!{}{}The Euro is introduced as the sole currency for everyday transactions in your country!
 STR_NEWS_BEGIN_OF_RECESSION                                     :{BIG_FONT}{BLACK}World Recession!{}{}Financial experts fear worst as economy slumps!
 STR_NEWS_END_OF_RECESSION                                       :{BIG_FONT}{BLACK}Recession Over!{}{}Upturn in trade gives confidence to industries as economy strengthens!

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -334,6 +334,7 @@ static const NewsTypeData _news_type_data[] = {
 	NewsTypeData("news_display.advice",           150, SND_BEGIN       ),  ///< NewsType::Advice
 	NewsTypeData("news_display.new_vehicles",      30, SND_1E_NEW_ENGINE), ///< NewsType::NewVehicles
 	NewsTypeData("news_display.acceptance",        90, SND_BEGIN       ),  ///< NewsType::Acceptance
+	NewsTypeData("news_display.cargo_flow",        90, SND_BEGIN       ),  ///< NewsType::CargoFlow
 	NewsTypeData("news_display.subsidies",        180, SND_BEGIN       ),  ///< NewsType::Subsidies
 	NewsTypeData("news_display.general",           60, SND_BEGIN       ),  ///< NewsType::General
 };

--- a/src/news_type.h
+++ b/src/news_type.h
@@ -44,6 +44,7 @@ enum class NewsType : uint8_t {
 	Advice, ///< Bits of news about vehicles of the company
 	NewVehicles, ///< New vehicle has become available
 	Acceptance, ///< A type of cargo is (no longer) accepted
+	CargoFlow, ///< Cargo flow warnings (overflowing cargo)
 	Subsidies, ///< News about subsidies (announcements, expirations, acceptance)
 	General, ///< General news (from towns)
 

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -902,6 +902,7 @@ SettingsContainer &GetSettingsTree()
 			advisors->Add(new SettingEntry("news_display.accident_other"));
 			advisors->Add(new SettingEntry("news_display.company_info"));
 			advisors->Add(new SettingEntry("news_display.acceptance"));
+			advisors->Add(new SettingEntry("news_display.cargo_flow"));
 			advisors->Add(new SettingEntry("news_display.arrival_player"));
 			advisors->Add(new SettingEntry("news_display.arrival_other"));
 			advisors->Add(new SettingEntry("news_display.advice"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -541,6 +541,7 @@ struct NewsSettings {
 	uint8_t advice;                                       ///< NewsDisplay on advice affecting the player's vehicles
 	uint8_t new_vehicles;                                 ///< NewsDisplay of new vehicles becoming available
 	uint8_t acceptance;                                   ///< NewsDisplay on changes affecting the acceptance of cargo at stations
+	uint8_t cargo_flow;                                   ///< NewsDisplay when cargo is accumulating at a station
 	uint8_t subsidies;                                    ///< NewsDisplay of changes on subsidies
 	uint8_t general;                                      ///< NewsDisplay of other topics
 };

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -941,6 +941,8 @@ public:
 
 	void UpdateCargoHistory();
 
+	void CheckCargoOverflow() const;
+
 	void MoveSign(TileIndex new_xy) override;
 
 	void AfterStationTileSetChange(bool adding, StationType type);

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -571,7 +571,7 @@ void Station::CheckCargoOverflow() const
 	if (overflowing_cargoes.Any()) {
 		AddNewsItem(
 				GetEncodedString(STR_STATION_CARGO_OVERFLOW, overflowing_cargoes, this->index),
-				NewsType::Acceptance,
+				NewsType::CargoFlow,
 				NewsStyle::Small,
 				NewsFlag::InColour,
 				this->index);
@@ -4819,7 +4819,7 @@ void StationMonthlyLoop()
 			ge.status.Set(GoodsEntry::State::LastMonth, ge.status.Test(GoodsEntry::State::CurrentMonth));
 			ge.status.Reset(GoodsEntry::State::CurrentMonth);
 		}
-		st->CheckCargoOverflow();
+		if (_settings_client.news_display.cargo_flow > 0 && st->owner == _local_company) st->CheckCargoOverflow();
 	}
 }
 

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -518,6 +518,66 @@ void Station::UpdateCargoHistory()
 	if (update_window) InvalidateWindowData(WC_STATION_VIEW, this->index, -1);
 }
 
+static bool CheckStationCargoHistroyOverflow(const std::array<uint16_t, MAX_STATION_CARGO_HISTORY_DAYS> &history, const uint8_t history_offset)
+{
+	/* Sum of intra-day differences. This is a decent proxy
+	 * for estimating how active the station is */
+	uint32_t cumulative_diff = 0;
+
+	uint8_t index_last = ((history_offset == 0) ? MAX_STATION_CARGO_HISTORY_DAYS : history_offset) - 1;
+	uint32_t first = RXDecompressUint(history[history_offset]);
+	uint32_t last = RXDecompressUint(history[index_last]);
+	uint32_t prev = first;
+	/* If amount of cargo decreased, don't warn. */
+	if (last < first) return false;
+
+	auto advance_index = [](uint8_t index) -> uint8_t {
+		index++;
+		return index == MAX_STATION_CARGO_HISTORY_DAYS ? 0 : index;
+	};
+	for (uint8_t i = advance_index(history_offset); i != history_offset; i = advance_index(i)) {
+		uint32_t current = RXDecompressUint(history[i]);
+
+		/* If amount of cargo was 0 at some point, don't warn. */
+		if (current == 0) return false;
+		cumulative_diff += Delta(current, prev);
+		prev = current;
+	}
+
+	/* If there wasn't any change at all, don't warn.
+	 * If sum of intra-day differences is more than 33% of total waiting amount,
+	 * don't warn (regardless of change direction - the point of the warning is
+	 * specifically to warn about stations with a lot of accumulated cargo
+	 * relative to how active the station is). */
+	return (cumulative_diff != 0 && cumulative_diff * 3 < last);
+}
+
+/**
+ * Check whether cargo is overflowing
+ */
+void Station::CheckCargoOverflow() const
+{
+	/* Identify cargoes with relatively low activity and high waiting amount
+	 * and warn the player about overflowing cargoes */
+	uint storage_offset = 0;
+	CargoTypes overflowing_cargoes{};
+	for (CargoType c : this->station_cargo_history_cargoes) {
+		if (CheckStationCargoHistroyOverflow(this->station_cargo_history[storage_offset], this->station_cargo_history_offset)) {
+			overflowing_cargoes.Set(c);
+		}
+		storage_offset++;
+	}
+
+	if (overflowing_cargoes.Any()) {
+		AddNewsItem(
+				GetEncodedString(STR_STATION_CARGO_OVERFLOW, overflowing_cargoes, this->index),
+				NewsType::Acceptance,
+				NewsStyle::Small,
+				NewsFlag::InColour,
+				this->index);
+	}
+}
+
 /**
  * Update the virtual coords needed to draw the station sign.
  */
@@ -4759,6 +4819,7 @@ void StationMonthlyLoop()
 			ge.status.Set(GoodsEntry::State::LastMonth, ge.status.Test(GoodsEntry::State::CurrentMonth));
 			ge.status.Reset(GoodsEntry::State::CurrentMonth);
 		}
+		st->CheckCargoOverflow();
 	}
 }
 

--- a/src/table/settings/news_display_settings.ini
+++ b/src/table/settings/news_display_settings.ini
@@ -196,6 +196,17 @@ strhelp  = STR_CONFIG_SETTING_NEWS_CHANGES_ACCEPTANCE_HELPTEXT
 strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 
 [SDTC_OMANY]
+var      = news_display.cargo_flow
+type     = SLE_UINT8
+flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown, SettingFlag::Patch
+def      = 0
+max      = 2
+full     = _news_display
+str      = STR_CONFIG_SETTING_NEWS_CARGO_FLOW
+strhelp  = STR_CONFIG_SETTING_NEWS_CARGO_FLOW_HELPTEXT
+strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
+
+[SDTC_OMANY]
 var      = news_display.subsidies
 type     = SLE_UINT8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown


### PR DESCRIPTION
Making use of station cargo history data, this code checks each month whether the data indicates that a given cargo is accumulating.

In English: when the graph is a gentle upward line at the top of the graph window, the cargo is probably overflowing.

Specifically: if the sum of absolute values of intra-day cargo amount differences is less than 1/3 current cargo amount, we warn the player that the cargo is overflowing, except when
 - the amount of cargo between first and last data point decreased
 - the amount of waiting cargo didn't change at all at any point
 - the amount was 0 at some point

I added this news item as cargo acceptance type, but if it's desirable to add a new type and a corresponding option, I can do that.

I tried to come up with something that will work reasonably well for everything from simple lorry stop to giant transfer hubs without obvious false positives, but I welcome suggestions how to improve it. I decided to not use any minimum threshold to not exclude the single lorry stop side of the spectrum. Another thing that has to be kept in mind is the effect of decreasing station rating and cargo expiry, which could cause false negatives. Length of the history also imposes some limits on how accurate we can be here.

I hope I didn't violate coding standards too badly.