### PR TITLE
Update NewGRF reload - keep hidden vehicles hidden

### DIFF
--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -4735,6 +4735,11 @@ void ReloadNewGRFData()
 		rail_type_label_map[rt] = GetRailTypeInfo(rt)->label;
 	}
 
+	std::vector<std::pair<EngineID, CompanyMask>> hidden_vehicles;
+	for (const Engine *e : Engine::Iterate()) {
+		if (e->company_hidden.Any()) hidden_vehicles.emplace_back(e->index, e->company_hidden);
+	}
+
 	/* reload grf data */
 	GfxLoadSprites();
 	RecomputePrices();
@@ -4772,6 +4777,11 @@ void ReloadNewGRFData()
 			RailType secondary = GetTileSecondaryRailTypeIfValid(t);
 			if (secondary != INVALID_RAILTYPE) SetSecondaryRailType(t, rail_type_translate_map[secondary]);
 		}
+	}
+
+	for (auto [eid, hidden] : hidden_vehicles) {
+		Engine *e = Engine::GetIfValid(eid);
+		if (e != nullptr) e->company_hidden = hidden;
 	}
 
 	UpdateExtraAspectsVariable();


### PR DESCRIPTION
What it says on the tin. Vehicles in _available vehicles_ window that were hidden before NewGRF is reloaded stay hidden after it is reloaded. Does not affect `resetengines` command.

From what I can tell, there's no issue with using `EngineID` to identify the vehicles before/after and testing showed no issues either. I can update it to use the _NewGRF ID / local id / type_ combination if `EngineID` would lead to some edge cases.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
