### PR TITLE
Add: "Order Stop Location" conditional for programmable signals

### DIFF
--- a/src/lang/extra/english.txt
+++ b/src/lang/extra/english.txt
@@ -874,6 +874,7 @@ STR_TRACE_RESTRICT_VARIABLE_MAX_SPEED                           :max speed
 STR_TRACE_RESTRICT_VARIABLE_CURRENT_ORDER                       :current order
 STR_TRACE_RESTRICT_VARIABLE_NEXT_ORDER                          :next order
 STR_TRACE_RESTRICT_VARIABLE_LAST_VISITED_STATION                :last visited station
+STR_TRACE_RESTRICT_VARIABLE_ORDER_STOP_LOCATION                 :order stop location
 STR_TRACE_RESTRICT_VARIABLE_CARGO                               :cargo
 STR_TRACE_RESTRICT_VARIABLE_LOAD_PERCENT                        :load percentage
 STR_TRACE_RESTRICT_VARIABLE_ENTRY_DIRECTION                     :entry direction
@@ -917,6 +918,7 @@ STR_TRACE_RESTRICT_CONDITIONAL_COMPARE_TIME_HHMM                :{STRING} {STRIN
 STR_TRACE_RESTRICT_CONDITIONAL_ORDER_STATION                    :{STRING} {STRING} {STRING} {STATION} then
 STR_TRACE_RESTRICT_CONDITIONAL_ORDER_WAYPOINT                   :{STRING} {STRING} {STRING} {WAYPOINT} then
 STR_TRACE_RESTRICT_CONDITIONAL_ORDER_DEPOT                      :{STRING} {STRING} {STRING} {DEPOT} then
+STR_TRACE_RESTRICT_CONDITIONAL_ORDER_STOP_LOCATION              :{STRING} current order stop location {STRING} {STRING} then
 STR_TRACE_RESTRICT_CONDITIONAL_CARGO                            :{STRING} train {STRING} cargo: {STRING} then
 STR_TRACE_RESTRICT_CONDITIONAL_ENTRY_DIRECTION                  :{STRING} train {STRING} entering from {STRING} tile edge then
 STR_TRACE_RESTRICT_CONDITIONAL_ENTRY_SIGNAL_FACE                :{STRING} train {STRING} entering from {STRING} of signal then

--- a/src/sl/extended_ver_sl.cpp
+++ b/src/sl/extended_ver_sl.cpp
@@ -77,7 +77,7 @@ static uint32_t saveSTC(const SlxiSubChunkInfo &info, bool dry_run);
 const std::initializer_list<SlxiSubChunkInfo> _sl_xv_sub_chunk_infos = {
 	{ XSLFI_VERSION_LABEL,                    XSCF_IGNORABLE_ALL,       1,   1, "version_label",                    saveVL,  loadVL,  nullptr          },
 	{ XSLFI_UPSTREAM_VERSION,                 XSCF_NULL,                2,   2, "upstream_version",                 saveUV,  loadUV,  nullptr          },
-	{ XSLFI_TRACE_RESTRICT,                   XSCF_NULL,               22,  22, "tracerestrict",                    nullptr, nullptr, "TRRM,TRRP,TRRS,TRRG,TRRB" },
+	{ XSLFI_TRACE_RESTRICT,                   XSCF_NULL,               23,  23, "tracerestrict",                    nullptr, nullptr, "TRRM,TRRP,TRRS,TRRG,TRRB" },
 	{ XSLFI_TRACE_RESTRICT_OWNER,             XSCF_NULL,                1,   1, "tracerestrict_owner",              nullptr, nullptr, nullptr          },
 	{ XSLFI_TRACE_RESTRICT_ORDRCND,           XSCF_NULL,                4,   4, "tracerestrict_order_cond",         nullptr, nullptr, nullptr          },
 	{ XSLFI_TRACE_RESTRICT_STATUSCND,         XSCF_NULL,                2,   2, "tracerestrict_status_cond",        nullptr, nullptr, nullptr          },

--- a/src/tracerestrict.cpp
+++ b/src/tracerestrict.cpp
@@ -359,6 +359,21 @@ static bool TestOrderCondition(const Order *order, TraceRestrictInstructionItem 
 }
 
 /**
+ * Test Stop location condition
+ * @p order may be nullptr
+ */
+static bool TestOrderStopLocationCondition(const Order *order, TraceRestrictInstructionItem item)
+{
+	bool result = false;
+
+	if (order != nullptr) {
+		const OrderStopLocation stop_location = static_cast<OrderStopLocation>(item.GetValue());
+		result = order->GetStopLocation() == stop_location;
+	}
+	return TestBinaryConditionCommon(item, result);
+}
+
+/**
  * Test station condition
  */
 static bool TestStationCondition(StationID station, TraceRestrictInstructionItem item)
@@ -555,6 +570,10 @@ void TraceRestrictProgram::Execute(const Train *v, const TraceRestrictProgramInp
 
 					case TRIT_COND_LAST_STATION:
 						result = TestStationCondition(v->last_station_visited, item);
+						break;
+
+					case TRIT_COND_ORDER_STOP_LOCATION:
+						result = TestOrderStopLocationCondition(&(v->current_order), item);
 						break;
 
 					case TRIT_COND_CARGO: {
@@ -1489,6 +1508,21 @@ CommandCost TraceRestrictProgram::Validate(const std::span<const TraceRestrictPr
 					}
 					break;
 
+				case TRIT_COND_ORDER_STOP_LOCATION:
+					if (invalid_binary_condition()) return unknown_instruction();
+					switch (static_cast<OrderStopLocation>(item.GetValue())) {
+						case OrderStopLocation::NearEnd:
+						case OrderStopLocation::Middle:
+						case OrderStopLocation::FarEnd:
+						case OrderStopLocation::Through:
+							break;
+
+						default:
+							return unknown_instruction();
+					}
+
+					break;
+
 				case TRIT_COND_TRAIN_STATUS:
 					if (invalid_binary_condition()) return unknown_instruction();
 					switch (static_cast<TraceRestrictTrainStatusValueField>(item.GetValue())) {
@@ -1556,6 +1590,7 @@ CommandCost TraceRestrictProgram::Validate(const std::span<const TraceRestrictPr
 				case TRIT_COND_NEXT_ORDER:
 				case TRIT_COND_LAST_STATION:
 				case TRIT_COND_TARGET_DIRECTION:
+				case TRIT_COND_ORDER_STOP_LOCATION:
 					actions_used_flags |= TRPAUF_ORDER_CONDITIONALS;
 					break;
 
@@ -2044,6 +2079,10 @@ void SetTraceRestrictValueDefault(TraceRestrictInstructionItemRef item, TraceRes
 
 		case TRVT_LABEL_INDEX:
 			item.SetValue(UINT16_MAX);
+			break;
+
+		case TRVT_ORDER_STOP_LOCATION:
+			item.SetValue(gui_context ? static_cast<uint16_t>(_settings_client.gui.stop_location) : 0);
 			break;
 
 		default:

--- a/src/tracerestrict.h
+++ b/src/tracerestrict.h
@@ -189,6 +189,7 @@ enum TraceRestrictItemType : uint8_t {
 	TRIT_COND_TARGET_DIRECTION    = 31,   ///< Test direction of order target tile relative to this signal tile
 	TRIT_COND_RESERVATION_THROUGH = 32,   ///< Test if train reservation passes through tile
 	TRIT_COND_TRAIN_IN_SLOT_GROUP = 33,   ///< Test train slot membership
+	TRIT_COND_ORDER_STOP_LOCATION = 34,   ///< Test train stop location (near/middle/far/through load)
 
 	TRIT_COND_END                 = 48,   ///< End (exclusive) of conditional item types, note that this has the same value as TRIT_REVERSE
 	TRIT_REVERSE                  = 48,   ///< Reverse behind/at signal
@@ -1071,6 +1072,7 @@ enum TraceRestrictValueType : uint8_t {
 	TRVT_ORDER_TARGET_DIAGDIR,     ///< takes a DiagDirection, and the order type in the auxiliary field
 	TRVT_TILE_INDEX_THROUGH,       ///< takes a TileIndex in the next item slot (passes through)
 	TRVT_LABEL_INDEX,              ///< takes a label ID
+	TRVT_ORDER_STOP_LOCATION,      ///< takes an OrderStopLocation
 };
 
 /**
@@ -1114,6 +1116,11 @@ inline TraceRestrictTypePropertySet GetTraceRestrictTypeProperties(TraceRestrict
 			case TRIT_COND_NEXT_ORDER:
 			case TRIT_COND_LAST_STATION:
 				out.value_type = TRVT_ORDER;
+				out.cond_type = TRCOT_BINARY;
+				break;
+
+			case TRIT_COND_ORDER_STOP_LOCATION:
+				out.value_type = TRVT_ORDER_STOP_LOCATION;
 				out.cond_type = TRCOT_BINARY;
 				break;
 

--- a/src/tracerestrict_gui.cpp
+++ b/src/tracerestrict_gui.cpp
@@ -551,6 +551,25 @@ static const TraceRestrictDropDownListSet _signal_mode_control_value = {
 	_signal_mode_control_value_str, _signal_mode_control_value_val,
 };
 
+
+static const StringID _stop_location_value_str[] = {
+	STR_CONFIG_SETTING_STOP_LOCATION_NEAR_END,
+	STR_CONFIG_SETTING_STOP_LOCATION_MIDDLE,
+	STR_CONFIG_SETTING_STOP_LOCATION_FAR_END,
+	STR_CONFIG_SETTING_STOP_LOCATION_THROUGH
+};
+static const uint _stop_location_value_val[] = {
+	to_underlying(OrderStopLocation::NearEnd),
+	to_underlying(OrderStopLocation::Middle),
+	to_underlying(OrderStopLocation::FarEnd),
+	to_underlying(OrderStopLocation::Through),
+};
+
+/** value drop down list for OrderStopLocation strings and values */
+static const TraceRestrictDropDownListSet _stop_location_value = {
+	_stop_location_value_str, _stop_location_value_val,
+};
+
 /**
  * Get index of @p value in @p list_set
  * if @p value is not present, assert if @p missing_ok is false, otherwise return -1
@@ -639,6 +658,7 @@ static std::span<const TraceRestrictDropDownListItem> GetConditionDropDownListIt
 		{ TRIT_COND_CURRENT_ORDER,                                    STR_TRACE_RESTRICT_VARIABLE_CURRENT_ORDER,             TRDDLIF_NONE },
 		{ TRIT_COND_NEXT_ORDER,                                       STR_TRACE_RESTRICT_VARIABLE_NEXT_ORDER,                TRDDLIF_NONE },
 		{ TRIT_COND_LAST_STATION,                                     STR_TRACE_RESTRICT_VARIABLE_LAST_VISITED_STATION,      TRDDLIF_NONE },
+		{ TRIT_COND_ORDER_STOP_LOCATION,                              STR_TRACE_RESTRICT_VARIABLE_ORDER_STOP_LOCATION,       TRDDLIF_NONE },
 		{ TRIT_COND_CARGO,                                            STR_TRACE_RESTRICT_VARIABLE_CARGO,                     TRDDLIF_NONE },
 		{ TRIT_COND_LOAD_PERCENT,                                     STR_TRACE_RESTRICT_VARIABLE_LOAD_PERCENT,              TRDDLIF_NONE },
 		{ TRIT_COND_ENTRY_DIRECTION,                                  STR_TRACE_RESTRICT_VARIABLE_ENTRY_DIRECTION,           TRDDLIF_NONE },
@@ -1870,6 +1890,13 @@ static void FillInstructionString(format_buffer &instruction_string, const Trace
 							GetDropDownStringByValue(&_diagdir_value, item.GetValue()));
 					break;
 
+				case TRVT_ORDER_STOP_LOCATION:
+					set_instruction(STR_TRACE_RESTRICT_CONDITIONAL_ORDER_STOP_LOCATION,
+							_program_cond_type[item.GetCondFlags()],
+							GetDropDownStringByValue(GetCondOpDropDownListSet(properties), item.GetCondOp()),
+							GetDropDownStringByValue(&_stop_location_value, item.GetValue()));
+					break;
+
 				default:
 					NOT_REACHED();
 					break;
@@ -2650,6 +2677,13 @@ public:
 					case TRVT_ORDER_TARGET_DIAGDIR:
 						this->ShowDropDownListWithValue(&_diagdir_value, item.GetValue(), false, TR_WIDGET_VALUE_DROPDOWN, 0, 0);
 						break;
+
+					case TRVT_ORDER_STOP_LOCATION: {
+						uint hidden = 0;
+						if (!_settings_client.gui.show_adv_load_mode_features) hidden |= 8;
+						this->ShowDropDownListWithValue(&_stop_location_value, item.GetValue(), false, TR_WIDGET_VALUE_DROPDOWN, 0, hidden);
+						break;
+					}
 
 					default:
 						break;
@@ -4125,6 +4159,12 @@ private:
 
 						case TRVT_LABEL_INDEX:
 							right_sel->SetDisplayedPlane(DPR_LABEL_BUTTON);
+							break;
+
+						case TRVT_ORDER_STOP_LOCATION:
+							right_sel->SetDisplayedPlane(DPR_VALUE_DROPDOWN);
+							this->EnableWidget(TR_WIDGET_VALUE_DROPDOWN);
+							this->GetWidget<NWidgetCore>(TR_WIDGET_VALUE_DROPDOWN)->SetString(GetDropDownStringByValue(&_stop_location_value, item.GetValue()));
 							break;
 
 						default:


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
Fairly easy to add. Lets the player use the "stop location" part of the order as an implicit routing restriction. I'm planning to use this to prevent through trains (normally stopping in the middle of the platform) from using bay platforms.


## Description
Seems self-explanatory. New conditional type and supplemental variable type for conditional orders. Store the OrderStopLocation enum in the Value part of the conditional, keep the boolean conditional, evaluate and validate as needed.

Have tried to hide the "through load" option if the setting for it is disabled on the client.

## Limitations
Has had some testing but not in multiplayer, can't see why there'd be any issues there.

Wasn't sure about the best place in the list to put the new condition. In the code I've tried to put it at the end of relevant switches.

I'm new to making UI in OpenTTD.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
